### PR TITLE
feat: use feat name if featureDict key not available

### DIFF
--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -5,6 +5,9 @@ export default function getFeatures(item) {
         return {}
     }
 
+    // my intention is to deploy the frontend with teh existing feature dict
+    // to migrate the old feature.name s new ones
+    // and then to get rid of this dict
     const featureDict = {
         online_only: 'Online Only',
         online_account_opening: 'Online Account Opening',
@@ -36,6 +39,9 @@ export default function getFeatures(item) {
             // it's a feature we're interested in
             const displayFeature = getDisplayFeature(bankFeature)
             result[featureDict[bankFeature.feature.name]] = displayFeature
+        } else {
+            const displayFeature = getDisplayFeature(bankFeature)
+            result[bankFeature.feature.name] = displayFeature
         }
     }
 


### PR DESCRIPTION
- features default to feature name if key not found in featureDict

The intention is to migrate the feature names manually in the backend and then to delete the featuredict in the frontend

DRAFT. This shouldn't be merged until FE can also query BE for featuretypes
