### PR TITLE
Fix CallToAction color scheme in light mode

### DIFF
--- a/components/CallToAction.vue
+++ b/components/CallToAction.vue
@@ -19,7 +19,9 @@
             <div class="text-xs text-gray-500 mx-4 uppercase">
                 Or
             </div>
-            <NuxtLink to="/pledge" class="underline text-white">Pledge to Move It
+            <NuxtLink to="/pledge" 
+                :class="['underline', light ? 'text-gray-800' : 'text-white' ]">
+                Pledge to Move It
             </NuxtLink>
         </div>
     </div>


### PR DESCRIPTION
Use contrasted color for underline link under light mode.