### PR TITLE
only enable gtm when cookies are allowed

### DIFF
--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -26,7 +26,6 @@ import { useGtm } from '@gtm-support/vue-gtm'
 const showBanner = useCookie('bg.showbanner', { default: () => true })
 const allowCookies = useCookie('bg.allowcookies', { default: () => false })
 function yesCookies() {
-    console.log('yes cookies!')
     showBanner.value = false
     allowCookies.value = true
     const gtm = useGtm()

--- a/components/CookieBanner.vue
+++ b/components/CookieBanner.vue
@@ -21,11 +21,16 @@
 </template>
 
 <script setup>
+import { useGtm } from '@gtm-support/vue-gtm'
+
 const showBanner = useCookie('bg.showbanner', { default: () => true })
 const allowCookies = useCookie('bg.allowcookies', { default: () => false })
 function yesCookies() {
+    console.log('yes cookies!')
     showBanner.value = false
     allowCookies.value = true
+    const gtm = useGtm()
+    gtm.enable()
 }
 
 function noCookies() {

--- a/composables/useContactForm.js
+++ b/composables/useContactForm.js
@@ -67,15 +67,16 @@ export default function useContactForm(
         })
         isSent.value = true
 
-        let gtmEvent = 'emailform'
-        if (tag === 'contact page form') {
-            gtmEvent = 'contactpage'
+        const allowCookies = useCookie('bg.allowcookies', { default: () => false })
+        if (allowCookies.value) {
+            let gtmEvent = 'emailform'
+            if (tag === 'contact page form') {
+                gtmEvent = 'contactpage'
+            }
+            const gtm = useGtm()
+            gtm.enable(true)
+            gtm.trackEvent({ event: gtmEvent })
         }
-        const gtm = useGtm()
-        gtm.enable(true)
-        gtm.trackEvent({ event: gtmEvent })
-
-        isSent.value = true
 
         setTimeout(() => {
             // clear after some ms so that the view has been updated / we have paginated away

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -125,6 +125,8 @@ const { data: home } = await useAsyncData('home', () => client.getSingle('homepa
 usePrismicSEO(home.value.data)
 
 const onCheckBankClick = () => {
+    const allowCookies = useCookie('bg.allowcookies', { default: () => false })
+    if (!allowCookies.value) return
     const gtm = useGtm()
     gtm.enable(true)
     gtm.trackEvent({ event: 'onBankCheckClick' })

--- a/plugins/vue-gtm.client.js
+++ b/plugins/vue-gtm.client.js
@@ -18,6 +18,9 @@ export default defineNuxtPlugin((nuxtApp) => {
 
         // only enable after another delay
         setTimeout(async () => {
+            const allowCookies = useCookie('bg.allowcookies', { default: () => false })
+            if (!allowCookies.value) return
+            console.log('cookies allowed')
             const gtm = useGtm()
             gtm.enable()
         }, LOADING_DELAY_MS)


### PR DESCRIPTION
This enables GTM only when `allowcookies` is set.

To test, try clicking "allowCookies" on the cookie banner and checking the cookies. Or loading the page fresh somewhere, without having consented, and checking that they do not get set.