### PR TITLE
automatically resize images to have width 400 on frontpage

### DIFF
--- a/slices/FeaturedInSlice/index.vue
+++ b/slices/FeaturedInSlice/index.vue
@@ -1,5 +1,6 @@
 <template>
-  <img :src="slice.primary.logo.url" :alt="slice.primary.logo.alt" :class="slice.primary.class ?? 'h-10 w-auto'" />
+  <img :src='`${slice.primary.logo.url}&w=400`' :alt="slice.primary.logo.alt"
+    :class="slice.primary.class ?? 'h-10 w-auto'" />
 </template>
 
 <script>


### PR DESCRIPTION
Since we can't use the `nuxt-image` component yet, this PR manually adds the Prismic parameter that resizes the images on the frontpage, saving us about 100kb on each page load.