### PR TITLE
fix local branches filter

### DIFF
--- a/components/forms/RegionSearch.vue
+++ b/components/forms/RegionSearch.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="relative" v-clickaway="hideList">
-        <SearchInput :aria-expanded="isShowing" v-model="search" placeholder="Search region/state"
-            @keydown.down="onKeyDown" @keydown.up="onKeyUp" @keydown.enter="onKeyEnter" @onFocus="showList"
-            @onClick="showList" @onCloseClick="onCloseClick">
+        <SearchInput :aria-expanded="isShowing" v-model="search" placeholder="Search region/state" @keydown.down="onKeyDown"
+            @keydown.up="onKeyUp" @keydown.enter="onKeyEnter" @onFocus="showList" @onClick="showList"
+            @onCloseClick="onCloseClick">
             <template v-slot:icon>
                 <PinIcon class="h-6 w-6 absolute inset-0 m-4" />
             </template>
@@ -25,7 +25,7 @@
                     <div>
                         {{ item.toponymName
                         }}{{
-        item.fcode === 'ADM2' ? `, ${item.adminName1}` : ''
+    item.fcode === 'ADM2' ? `, ${item.adminName1}` : ''
 }}
                     </div>
                 </ListPicker>

--- a/components/forms/RegionSearch.vue
+++ b/components/forms/RegionSearch.vue
@@ -42,7 +42,7 @@ import ListPicker from '@/components/forms/ListPicker'
 import Geonames from 'geonames.js'
 import Fuse from 'fuse.js'
 
-const props = definePrpos({
+const props = defineProps({
     modelValue: String,
 })
 const listPicker = ref()

--- a/components/forms/RegionSearch.vue
+++ b/components/forms/RegionSearch.vue
@@ -45,6 +45,8 @@ import Fuse from 'fuse.js'
 const props = defineProps({
     modelValue: String,
 })
+
+const emit = defineEmits(['update:modelValue', 'select'])
 const listPicker = ref()
 const onKeyDown = (event) => {
     listPicker.value.incrementFocus(event)

--- a/components/forms/RegionSearch.vue
+++ b/components/forms/RegionSearch.vue
@@ -34,13 +34,20 @@
     </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import SearchInput from '@/components/forms/input/SearchInput'
+import SearchInput from '@/components/forms/input/SearchInput.vue'
 import PinIcon from './location/PinIcon.vue'
-import ListPicker from '@/components/forms/ListPicker'
+import ListPicker from '@/components/forms/ListPicker.vue'
 import Geonames from 'geonames.js'
 import Fuse from 'fuse.js'
+
+// custom type for responses from geonames API
+type Place = {
+    toponymName: string,
+    fcode: string,
+    adminName1: string
+}
 
 const props = defineProps({
     modelValue: String,
@@ -48,10 +55,10 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'select'])
 const listPicker = ref()
-const onKeyDown = (event) => {
+const onKeyDown = (event: Event) => {
     listPicker.value.incrementFocus(event)
 }
-const onKeyUp = (event) => {
+const onKeyUp = (event: Event) => {
     listPicker.value.decrementFocus(event)
 }
 const onKeyEnter = () => listPicker.value.selectCurrentItem()
@@ -62,7 +69,7 @@ const isLoading = ref(false)
 
 const { country } = useCountry()
 
-const options = ref([])
+const options = ref<Place[]>([])
 const geonames = Geonames({
     username: 'myusername',
     encoding: 'JSON',
@@ -75,7 +82,7 @@ const searchRegion = async () => {
         featureClass: 'A',
         featureCode: ['ADM1', 'ADM2'],
         maxRows: 1000,
-    })
+    }) as { geonames: Place[] }
     options.value = data.geonames.sort((a, b) =>
         a.toponymName.localeCompare(b.toponymName)
     )
@@ -92,7 +99,7 @@ const filteredOptions = computed(() => {
         return options.value
     }
     const result = fuse.search(search.value)
-    return result.filter((x) => x.score < 0.3).map((x) => x.item)
+    return result.filter((x) => x.score && (x.score < 0.3)).map((x) => x.item)
 })
 
 watch(
@@ -110,7 +117,7 @@ function showList() {
 function hideList() {
     isShowing.value = false
 }
-async function onSelectLocation(item) {
+async function onSelectLocation(item: Place) {
     emit('update:modelValue', '')
     await nextTick()
     search.value = item.toponymName


### PR DESCRIPTION
https://bank.green/sustainable-eco-banks

There were two mistakes in the Local Branches filter that somehow slipped by us (I believe when moving to SFC), I fixed them. To verify it works, if looking in the United Kingdom, you can filter for local branches in "Greater London" or "Oxfordshire". I migrated the component to TS as well since that would have caught this error (and made it easier to fix).