### PR TITLE
Display custom bank text

### DIFF
--- a/.slicemachine/assets/customtypes/bankpage/mocks.json
+++ b/.slicemachine/assets/customtypes/bankpage/mocks.json
@@ -14,32 +14,40 @@
     "headline": [
       {
         "type": "paragraph",
-        "text": "Laboris mollit est dolor labore proident nulla fugiat. Eiusmod ea pariatur aliquip anim velit et qui amet amet nulla aute consectetur elit.",
+        "text": "Cupidatat consectetur id mollit exercitation enim elit laborum.",
         "spans": []
       }
     ],
     "description1": [
       {
         "type": "paragraph",
-        "text": "Dolore elit aliquip qui amet commodo minim quis dolor id labore ut mollit aliqua elit. Consectetur nostrud do quis reprehenderit minim do tempor in.",
+        "text": "Esse dolor pariatur elit exercitation. Ea labore in esse sunt ea id.",
         "spans": []
       }
     ],
     "description2": [
       {
         "type": "paragraph",
-        "text": "Lorem qui reprehenderit incididunt commodo id labore cupidatat dolore nisi proident enim laborum dolore aliqua qui. Exercitation deserunt sit eu laboris proident reprehenderit aute anim duis non veniam nulla.",
+        "text": "Ea mollit ipsum in incididunt adipisicing dolor est qui anim. Dolore proident sit est adipisicing et pariatur culpa eiusmod nulla officia fugiat exercitation occaecat adipisicing enim. Laborum qui laboris sunt et culpa in dolor nisi.",
         "spans": []
       }
     ],
     "description3": [
       {
         "type": "paragraph",
-        "text": "Laborum quis anim laboris velit fugiat fugiat officia in nostrud ut nostrud elit ex incididunt. Nulla velit ea in. Ullamco nisi incididunt pariatur ea incididunt ea pariatur.",
+        "text": "Ipsum qui ipsum amet dolore duis pariatur aliquip tempor in.",
         "spans": []
       }
     ],
-    "seo_title": "dog",
-    "seo_description": "none"
+    "seo_title": "maybe",
+    "seo_description": "fast",
+    "subtitle": [
+      {
+        "type": "paragraph",
+        "text": "Do occaecat commodo commodo nulla velit exercitation proident aliquip.",
+        "spans": []
+      }
+    ],
+    "slices": []
   }
 }

--- a/.slicemachine/mock-config.json
+++ b/.slicemachine/mock-config.json
@@ -91,6 +91,12 @@
           "patternType": "PARAGRAPH",
           "blocks": 1
         }
+      },
+      "subtitle": {
+        "config": {
+          "patternType": "PARAGRAPH",
+          "blocks": 1
+        }
       }
     },
     "ecobankspage": {},

--- a/.slicemachine/prismicio.d.ts
+++ b/.slicemachine/prismicio.d.ts
@@ -114,7 +114,34 @@ interface BankpageDocumentData {
      *
      */
     seo_description: prismicT.KeyTextField;
+    /**
+     * Custom Subtitle field in *BankPage*
+     *
+     * - **Field Type**: Rich Text
+     * - **Placeholder**: *None*
+     * - **API ID Path**: bankpage.subtitle
+     * - **Tab**: Main
+     * - **Documentation**: https://prismic.io/docs/core-concepts/rich-text-title
+     *
+     */
+    subtitle: prismicT.RichTextField;
+    /**
+     * Slice Zone field in *BankPage*
+     *
+     * - **Field Type**: Slice Zone
+     * - **Placeholder**: *None*
+     * - **API ID Path**: bankpage.slices[]
+     * - **Tab**: Main
+     * - **Documentation**: https://prismic.io/docs/core-concepts/slices
+     *
+     */
+    slices: prismicT.SliceZone<BankpageDocumentDataSlicesSlice>;
 }
+/**
+ * Slice for *BankPage → Slice Zone*
+ *
+ */
+type BankpageDocumentDataSlicesSlice = never;
 /**
  * BankPage document from Prismic
  *
@@ -1522,6 +1549,6 @@ declare module "@prismicio/client" {
         (repositoryNameOrEndpoint: string, options?: prismic.ClientConfig): prismic.Client<AllDocumentTypes>;
     }
     namespace Content {
-        export type { AccordionitemDocumentData, AccordionitemDocumentDataSlicesSlice, AccordionitemDocument, BankpageDocumentData, BankpageDocument, BlogpostDocumentData, BlogpostDocumentDataSlicesSlice, BlogpostDocument, CalltoactionDocumentData, CalltoactionDocument, CertificationpageDocumentData, CertificationpageDocumentDataSlicesSlice, CertificationpageDocument, ContactpageDocumentData, ContactpageDocument, DisclaimerpageDocumentData, DisclaimerpageDocumentDataSlicesSlice, DisclaimerpageDocument, EcobankspageDocumentData, EcobankspageDocumentDataSlicesSlice, EcobankspageDocumentDataSlices1Slice, EcobankspageDocument, FaqpageDocumentData, FaqpageDocumentDataSlicesSlice, FaqpageDocument, HomepageDocumentData, HomepageDocumentDataSlices1Slice, HomepageDocument, PledgepageDocumentData, PledgepageDocument, PresspageDocumentData, PresspageDocumentDataSlicesSlice, PresspageDocument, PresspostDocumentData, PresspostDocumentDataSlicesSlice, PresspostDocument, PrivacypageDocumentData, PrivacypageDocumentDataSlicesSlice, PrivacypageDocument, TakeactionpageDocumentData, TakeactionpageDocumentDataSlices1Slice, TakeactionpageDocumentDataSlices2Slice, TakeactionpageDocumentDataSlices3Slice, TakeactionpageDocumentDataSlices4Slice, TakeactionpageDocument, TeampageDocumentData, TeampageDocumentDataSlicesSlice, TeampageDocument, VolunteerspageDocumentData, VolunteerspageDocumentDataSlicesSlice, VolunteerspageDocument, AllDocumentTypes, AccordionSliceSliceRichTextPrimary, AccordionSliceSliceRichText, AccordionSliceSliceRichTextWithStepPrimary, AccordionSliceSliceRichTextWithStep, AccordionSliceSliceDefaultPrimary, AccordionSliceSliceDefault, AccordionSliceSliceVariation, AccordionSliceSlice, ButtonSliceSliceDefaultPrimary, ButtonSliceSliceDefault, ButtonSliceSliceVariation, ButtonSliceSlice, EmbedSliceSliceDefaultPrimary, EmbedSliceSliceDefault, EmbedSliceSliceVariation, EmbedSliceSlice, FeaturedInSliceSliceDefaultPrimary, FeaturedInSliceSliceDefault, FeaturedInSliceSliceVariation, FeaturedInSliceSlice, ImageSliceSliceDefaultPrimary, ImageSliceSliceDefault, ImageSliceSliceVariation, ImageSliceSlice, SharePicGallerySliceSliceDefault, SharePicGallerySliceSliceVariation, SharePicGallerySliceSlice, SocialSharerSliceSliceDefault, SocialSharerSliceSliceVariation, SocialSharerSliceSlice, TextSliceSliceDefaultPrimary, TextSliceSliceDefault, TextSliceSliceVariation, TextSliceSlice };
+        export type { AccordionitemDocumentData, AccordionitemDocumentDataSlicesSlice, AccordionitemDocument, BankpageDocumentData, BankpageDocumentDataSlicesSlice, BankpageDocument, BlogpostDocumentData, BlogpostDocumentDataSlicesSlice, BlogpostDocument, CalltoactionDocumentData, CalltoactionDocument, CertificationpageDocumentData, CertificationpageDocumentDataSlicesSlice, CertificationpageDocument, ContactpageDocumentData, ContactpageDocument, DisclaimerpageDocumentData, DisclaimerpageDocumentDataSlicesSlice, DisclaimerpageDocument, EcobankspageDocumentData, EcobankspageDocumentDataSlicesSlice, EcobankspageDocumentDataSlices1Slice, EcobankspageDocument, FaqpageDocumentData, FaqpageDocumentDataSlicesSlice, FaqpageDocument, HomepageDocumentData, HomepageDocumentDataSlices1Slice, HomepageDocument, PledgepageDocumentData, PledgepageDocument, PresspageDocumentData, PresspageDocumentDataSlicesSlice, PresspageDocument, PresspostDocumentData, PresspostDocumentDataSlicesSlice, PresspostDocument, PrivacypageDocumentData, PrivacypageDocumentDataSlicesSlice, PrivacypageDocument, TakeactionpageDocumentData, TakeactionpageDocumentDataSlices1Slice, TakeactionpageDocumentDataSlices2Slice, TakeactionpageDocumentDataSlices3Slice, TakeactionpageDocumentDataSlices4Slice, TakeactionpageDocument, TeampageDocumentData, TeampageDocumentDataSlicesSlice, TeampageDocument, VolunteerspageDocumentData, VolunteerspageDocumentDataSlicesSlice, VolunteerspageDocument, AllDocumentTypes, AccordionSliceSliceRichTextPrimary, AccordionSliceSliceRichText, AccordionSliceSliceRichTextWithStepPrimary, AccordionSliceSliceRichTextWithStep, AccordionSliceSliceDefaultPrimary, AccordionSliceSliceDefault, AccordionSliceSliceVariation, AccordionSliceSlice, ButtonSliceSliceDefaultPrimary, ButtonSliceSliceDefault, ButtonSliceSliceVariation, ButtonSliceSlice, EmbedSliceSliceDefaultPrimary, EmbedSliceSliceDefault, EmbedSliceSliceVariation, EmbedSliceSlice, FeaturedInSliceSliceDefaultPrimary, FeaturedInSliceSliceDefault, FeaturedInSliceSliceVariation, FeaturedInSliceSlice, ImageSliceSliceDefaultPrimary, ImageSliceSliceDefault, ImageSliceSliceVariation, ImageSliceSlice, SharePicGallerySliceSliceDefault, SharePicGallerySliceSliceVariation, SharePicGallerySliceSlice, SocialSharerSliceSliceDefault, SocialSharerSliceSliceVariation, SocialSharerSliceSlice, TextSliceSliceDefaultPrimary, TextSliceSliceDefault, TextSliceSliceVariation, TextSliceSlice };
     }
 }

--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -14,7 +14,7 @@
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
                     <div v-if="header" v-html="header"></div>
-                    <PrismicRichText :field="bankPageData?.headline" />
+                    <PrismicRichText v-else :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
@@ -23,9 +23,9 @@
                     </div>
                 </div>  
 
-                <div v-if="bankPageData?.subtitle"
+                <div v-if="bankPage?.data.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPageData?.subtitle" />
+                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
         </template>
@@ -38,7 +38,8 @@
 </template>
 
 
-<script setup lang="ts">
+<script setup lang="ts">import { PrismicDocument } from '@prismicio/types';
+
 const props = defineProps<{
     name: string,
     website: string,
@@ -51,7 +52,7 @@ const props = defineProps<{
         tag: string
     },
     amountFinancedSince2016: string,
-    bankPageData: Record<string, any> | null,
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null,
 }>()
 
 const formattedTotal = computed(() => props.amountFinancedSince2016 ?? 'large amounts')

--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -14,7 +14,7 @@
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
                     <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="badbank?.data.headline" />
+                    <PrismicRichText :field="bankPageData?.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
@@ -23,9 +23,9 @@
                     </div>
                 </div>  
 
-                <div v-if="badbank?.data.subtitle"
+                <div v-if="bankPageData?.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="badbank.data.subtitle" />
+                    <PrismicRichText :field="bankPageData?.subtitle" />
                 </div>
             </div>
         </template>
@@ -50,13 +50,9 @@ const props = defineProps<{
         name: string,
         tag: string
     },
-    amountFinancedSince2016: string
+    amountFinancedSince2016: string,
+    bankPageData: Record<string, any> | null,
 }>()
-
-const { client } = usePrismic();
-
-const { data: badbank } = await useAsyncData("badbank", () =>
-    client.getByUID("bankpage", "badbank"))
 
 const formattedTotal = computed(() => props.amountFinancedSince2016 ?? 'large amounts')
 

--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -21,6 +21,11 @@
                     <div v-else>Your bank doesn't top the charts, but it’s still using your money to lend to fossil fuel
                         companies and projects that are rapidly accelerating the climate crisis.
                     </div>
+                </div>  
+
+                <div v-if="badbank?.data.subtitle"
+                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
+                    <PrismicRichText :field="badbank.data.subtitle" />
                 </div>
             </div>
         </template>

--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -1,7 +1,7 @@
 <template>
     <BankLayoutBadWorst>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" />
+            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -22,11 +22,6 @@
                         companies and projects that are rapidly accelerating the climate crisis.
                     </div>
                 </div>  
-
-                <div v-if="bankPage?.data.subtitle"
-                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPage.data.subtitle" />
-                </div>
             </div>
         </template>
 

--- a/components/bank/BankGreat.vue
+++ b/components/bank/BankGreat.vue
@@ -22,6 +22,11 @@
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else :field="greatbank?.data.description1" />
                 </div>
+
+                <div v-if="greatbank?.data.subtitle"
+                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
+                    <PrismicRichText :field="greatbank.data.subtitle" />
+                </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
                 <div class="relative flex-grow md:flex-none  text-center">

--- a/components/bank/BankGreat.vue
+++ b/components/bank/BankGreat.vue
@@ -1,7 +1,7 @@
 <template>
     <BankLayoutGreatOkUnknown>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" />
+            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -21,11 +21,6 @@
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else :field="bankPage?.data.description1" />
-                </div>
-
-                <div v-if="bankPage?.data.subtitle"
-                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">

--- a/components/bank/BankGreat.vue
+++ b/components/bank/BankGreat.vue
@@ -16,16 +16,16 @@
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
                     <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="greatbank?.data.headline" />
+                    <PrismicRichText v-else :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else :field="greatbank?.data.description1" />
+                    <PrismicRichText v-else :field="bankPage?.data.description1" />
                 </div>
 
-                <div v-if="greatbank?.data.subtitle"
+                <div v-if="bankPage?.data.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="greatbank.data.subtitle" />
+                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
@@ -41,7 +41,7 @@
                     <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                         <div class="md:w-1/2 max-w-sm">
                             <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4"
-                                :field="greatbank?.data.description2" />
+                                :field="bankPage?.data.description2" />
                             <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                                 Our mission is to encourage as many people as possible to take a
                                 stand - to refuse to let their money fuel environmental
@@ -73,6 +73,7 @@
 
 <script setup lang="ts">
 import ArrowDownBounce from "@/components/icons/ArrowDownBounce.vue";
+import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
@@ -83,12 +84,7 @@ const props = defineProps<{
     },
     fossilFreeAlliance: boolean,
     header: string,
-    summary: string
-}>()
-
-const { client } = usePrismic();
-
-const { data: greatbank } = await useAsyncData("greatbank", () =>
-    client.getByUID("bankpage", "greatbank")
-);
+    summary: string,
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null,
+}>();
 </script>

--- a/components/bank/BankHeadline.vue
+++ b/components/bank/BankHeadline.vue
@@ -10,7 +10,11 @@
                 <h1 class="text-xl md:text-2xl text-gray-800 font-medium md:font-semibold tracking-wider flex items-center">
                     {{ name }}
                 </h1>
-                <div v-if="subtitle" class="text-lg md:text-xl text-gray-500" v-html="subtitle"></div>
+                <div v-if="prismicFieldSubtitle"
+                    class="text-lg md:text-xl text-gray-500">
+                    <PrismicRichText :field="prismicFieldSubtitle" />
+                </div>
+                <div v-else-if="subtitle" class="text-lg md:text-xl text-gray-500" v-html="subtitle"></div>
                 <div v-if="inheritBrandRating" class="text-xs text-gray-500">Deposits or policies controlled by
                     <NuxtLink class="underline" :to="`/banks/${inheritBrandRating.tag}`">{{
                         inheritBrandRating.name }}</NuxtLink>
@@ -33,7 +37,8 @@ const props = defineProps({
     inheritBrandRating: {
         name: String,
         tag: String
-    }
+    },
+    prismicFieldSubtitle: undefined,
 })
 const bank = computed(() => props.details)
 

--- a/components/bank/BankOk.vue
+++ b/components/bank/BankOk.vue
@@ -1,7 +1,7 @@
 <template>
     <BankLayoutGreatOkUnknown>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" />
+            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating"  :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -18,11 +18,6 @@
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else :field="bankPage?.data.description1" />
-                </div>
-
-                <div v-if="bankPage?.data.subtitle"
-                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">

--- a/components/bank/BankOk.vue
+++ b/components/bank/BankOk.vue
@@ -19,6 +19,11 @@
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else :field="bankok?.data.description1" />
                 </div>
+
+                <div v-if="bankok?.data.subtitle"
+                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
+                    <PrismicRichText :field="bankok.data.subtitle" />
+                </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
                 <div class="relative flex-grow md:flex-none text-center">

--- a/components/bank/BankOk.vue
+++ b/components/bank/BankOk.vue
@@ -13,16 +13,16 @@
                 <div class="flex justify-center md:block mb-8 w-full"></div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
                     <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="bankok?.data.headline" />
+                    <PrismicRichText v-else :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else :field="bankok?.data.description1" />
+                    <PrismicRichText v-else :field="bankPage?.data.description1" />
                 </div>
 
-                <div v-if="bankok?.data.subtitle"
+                <div v-if="bankPage?.data.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankok.data.subtitle" />
+                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
@@ -35,7 +35,7 @@
         <template #section2>
             <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                 <div class="md:w-1/2 max-w-sm">
-                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4" :field="bankok?.data.description2" />
+                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4" :field="bankPage?.data.description2" />
                     <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                         Our mission is to encourage as many people as possible to take a
                         stand - to refuse to let their money fuel environmental
@@ -67,6 +67,7 @@
 
 <script setup lang="ts">
 import ArrowDownBounce from "@/components/icons/ArrowDownBounce.vue";
+import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
@@ -76,12 +77,7 @@ const props = defineProps<{
         name: string
     },
     header: string,
-    summary: string
+    summary: string,
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null,
 }>()
-
-const { client } = usePrismic();
-
-const { data: bankok } = await useAsyncData("okbank", () =>
-    client.getByUID("bankpage", "okbank")
-);
 </script>

--- a/components/bank/BankUnknown.vue
+++ b/components/bank/BankUnknown.vue
@@ -18,6 +18,11 @@
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap">
                     <PrismicRichText :field="bankunknown?.data.description1" />
                 </div>
+
+                <div v-if="bankunknown?.data.subtitle"
+                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
+                    <PrismicRichText :field="bankunknown.data.subtitle" />
+                </div>
             </div>
             <div class="col-span-2 md:col-span-1 flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
                 <div class="relative flex-grow md:flex-none  text-center">

--- a/components/bank/BankUnknown.vue
+++ b/components/bank/BankUnknown.vue
@@ -13,15 +13,15 @@
             <div class="col-span-2 md:col-span-1">
                 <div class="flex justify-center md:block mb-8 w-full"></div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    <PrismicRichText :field="bankunknown?.data.headline" />
+                    <PrismicRichText :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
-                    <PrismicRichText :field="bankunknown?.data.description1" />
+                    <PrismicRichText :field="bankPage?.data.description1" />
                 </div>
 
-                <div v-if="bankunknown?.data.subtitle"
+                <div v-if="bankPage?.data.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankunknown.data.subtitle" />
+                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
             <div
@@ -38,7 +38,7 @@
             <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                 <div class="md:w-1/2 max-w-sm">
                     <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4"
-                        :field="bankunknown?.data.description2" />
+                        :field="bankPage?.data.description2" />
                     <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                         Our mission is to encourage as many people as possible to take a
                         stand - to refuse to let their money fuel environmental
@@ -72,6 +72,7 @@
 
 <script setup lang="ts">
 import ArrowDownBounce from "@/components/icons/ArrowDownBounce.vue";
+import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
@@ -80,13 +81,8 @@ const props = defineProps<{
         tag: string,
         name: string
     },
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null
 }>()
-
-const { client } = usePrismic();
-
-const { data: bankunknown } = await useAsyncData("unknownbank", () =>
-    client.getByUID("bankpage", "unknownbank")
-);
 
 const checkList = [
     "Learn about the issues via our blog updates",

--- a/components/bank/BankUnknown.vue
+++ b/components/bank/BankUnknown.vue
@@ -19,10 +19,6 @@
                     <PrismicRichText :field="bankPage?.data.description1" />
                 </div>
 
-                <div v-if="bankPage?.data.subtitle"
-                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPage.data.subtitle" />
-                </div>
             </div>
             <div
                 class="col-span-2 md:col-span-1 flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
@@ -37,8 +33,7 @@
         <template #section2>
             <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                 <div class="md:w-1/2 max-w-sm">
-                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4"
-                        :field="bankPage?.data.description2" />
+                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4" :field="bankPage?.data.description2" />
                     <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                         Our mission is to encourage as many people as possible to take a
                         stand - to refuse to let their money fuel environmental

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -5,7 +5,8 @@
                 :name="name" 
                 :website="website" 
                 :subtitle="subtitle" 
-                :inheritBrandRating="inheritBrandRating" />
+                :inheritBrandRating="inheritBrandRating"
+                :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -23,11 +24,6 @@
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else-if="bankPage?.data" :field="bankPage?.data.description1" />
-                </div>
-
-                <div v-if="bankPage?.data && bankPage?.data.subtitle"
-                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
         </template>

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -19,7 +19,11 @@
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap">
                     <div v-if="summary" v-html="summary"></div>
                     <PrismicRichText v-else :field="worstbank?.data.description1" />
+                </div>
 
+                <div v-if="worstbank?.data.subtitle"
+                class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
+                    <PrismicRichText :field="worstbank.data.subtitle" />
                 </div>
             </div>
         </template>

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -1,7 +1,11 @@
 <template>
     <BankLayoutBadWorst>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" />
+            <BankHeadline 
+                :name="name" 
+                :website="website" 
+                :subtitle="subtitle" 
+                :inheritBrandRating="inheritBrandRating" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -14,16 +18,16 @@
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
                     <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="worstbank?.data.headline" />
+                    <PrismicRichText v-else-if="bankPage?.data" :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
                     <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else :field="worstbank?.data.description1" />
+                    <PrismicRichText v-else-if="bankPage?.data" :field="bankPage?.data.description1" />
                 </div>
 
-                <div v-if="worstbank?.data.subtitle"
+                <div v-if="bankPage?.data && bankPage?.data.subtitle"
                 class="prose sm:prose-lg xl:prose-xl prose-blurb whitespace-pre-wrap mt-1">
-                    <PrismicRichText :field="worstbank.data.subtitle" />
+                    <PrismicRichText :field="bankPage.data.subtitle" />
                 </div>
             </div>
         </template>
@@ -34,10 +38,9 @@
         </template>
     </BankLayoutBadWorst>
 </template>
-
-
-
 <script setup lang="ts">
+import { PrismicDocument } from '@prismicio/types'
+
 const props = defineProps<{
     name: string,
     website: string,
@@ -49,14 +52,9 @@ const props = defineProps<{
         name: string,
         tag: string
     },
-    amountFinancedSince2016: string
+    amountFinancedSince2016: string,
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null
 }>()
-
-const { client } = usePrismic();
-
-const { data: worstbank } = await useAsyncData("worstbank", () =>
-    client.getByUID("bankpage", "worstbank")
-);
 
 const formattedTotal = computed(() => props.amountFinancedSince2016 ?? 'large amounts')
 

--- a/constants/customBankTags.js
+++ b/constants/customBankTags.js
@@ -1,0 +1,3 @@
+export default [
+    'jpmorgan_chase'
+]

--- a/constants/customBankTags.js
+++ b/constants/customBankTags.js
@@ -1,3 +1,0 @@
-export default [
-    'jpmorgan_chase'
-]

--- a/customtypes/bankpage/index.json
+++ b/customtypes/bankpage/index.json
@@ -61,6 +61,22 @@
           "label": "SEO Description",
           "placeholder": ""
         }
+      },
+      "subtitle": {
+        "type": "StructuredText",
+        "config": {
+          "label": "Custom Subtitle",
+          "placeholder": "",
+          "allowTargetBlank": true,
+          "multi": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
+        }
+      },
+      "slices": {
+        "type": "Slices",
+        "fieldset": "Slice Zone",
+        "config": {
+          "choices": {}
+        }
       }
     }
   }

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -2,18 +2,20 @@
     <!-- :summary, :header, :details, :amountFinancedSince2016 to be removed 
         https://linear.app/bankgreen/issue/PE-476/render-custom-bank-texts-from-prismic
     -->
-    <component v-if="details" :is="componentName"
-        :name="details.name" 
-        :subtitle="details.subtitle"
-        :website="details.website" 
-        :inheritBrandRating="details.inheritBrandRating" 
-        :header="details.header"
-        :summary="details.summary" 
-        :details="details.details" 
-        :amountFinancedSince2016="details.amountFinancedSince2016"
-        :fossilFreeAlliance="details.fossilFreeAlliance"
-        :bankPage="bankPage"
-    />
+    <ClientOnly>
+        <component v-if="details" :is="componentName"
+            :name="details.name" 
+            :subtitle="details.subtitle"
+            :website="details.website" 
+            :inheritBrandRating="details.inheritBrandRating" 
+            :header="details.header"
+            :summary="details.summary" 
+            :details="details.details" 
+            :amountFinancedSince2016="details.amountFinancedSince2016"
+            :fossilFreeAlliance="details.fossilFreeAlliance"
+            :bankPage="bankPage"
+        />
+    </ClientOnly>
 </template>
 
 <script setup lang="ts">

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -29,7 +29,7 @@ const router = useRouter();
 const bankTag = router.currentRoute.value.params.bankTag;
 const details = ref(await getBankDetail(bankTag));
 
-const { bankPage } = await useBankPage(details);
+const { bankPage } = await useBankPage(bankTag, details);
 
 useHeadHelper(
     details.value?.name
@@ -47,16 +47,8 @@ const BankBad = resolveComponent('BankBad');
 const BankOk = resolveComponent('BankOk');
 const BankGreat = resolveComponent('BankGreat');
 
-const CUSTOM_BANKTAGS = [
-    'jpmorgan_chase',
-]
 
 const componentName = computed(() => {
-    const isCustomBankTag = CUSTOM_BANKTAGS.includes(router.currentRoute.value.params.bankTag as string);
-    
-    if (isCustomBankTag) {
-        // TODO: add custom component here
-    }
     const hasDetails = details.value && details.value.rating;
     if (!hasDetails)
         return undefined;

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -2,8 +2,16 @@
     <!-- :summary, :header, :details, :amountFinancedSince2016 to be removed 
         https://linear.app/bankgreen/issue/PE-476/render-custom-bank-texts-from-prismic
     -->
-    <component v-if="componentName" :is="componentName"
-        :details="details"
+    <component v-if="details" :is="componentName"
+        :name="details.name" 
+        :subtitle="details.subtitle"
+        :website="details.website" 
+        :inheritBrandRating="details.inheritBrandRating" 
+        :header="details.header"
+        :summary="details.summary" 
+        :details="details.details" 
+        :amountFinancedSince2016="details.amountFinancedSince2016"
+        :fossilFreeAlliance="details.fossilFreeAlliance"
         :bankPage="bankPage"
     />
     <!-- <BankWorst v-if="details.rating === 'worst'" :name="details.name" :subtitle="details.subtitle"

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -2,20 +2,18 @@
     <!-- :summary, :header, :details, :amountFinancedSince2016 to be removed 
         https://linear.app/bankgreen/issue/PE-476/render-custom-bank-texts-from-prismic
     -->
-    <ClientOnly>
-        <component v-if="details" :is="componentName"
-            :name="details.name" 
-            :subtitle="details.subtitle"
-            :website="details.website" 
-            :inheritBrandRating="details.inheritBrandRating" 
-            :header="details.header"
-            :summary="details.summary" 
-            :details="details.details" 
-            :amountFinancedSince2016="details.amountFinancedSince2016"
-            :fossilFreeAlliance="details.fossilFreeAlliance"
-            :bankPage="bankPage"
-        />
-    </ClientOnly>
+    <component v-if="details" :is="componentName"
+        :name="details.name" 
+        :subtitle="details.subtitle"
+        :website="details.website" 
+        :inheritBrandRating="details.inheritBrandRating" 
+        :header="details.header"
+        :summary="details.summary" 
+        :details="details.details" 
+        :amountFinancedSince2016="details.amountFinancedSince2016"
+        :fossilFreeAlliance="details.fossilFreeAlliance"
+        :bankPage="bankPage"
+    />
 </template>
 
 <script setup lang="ts">

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -47,10 +47,20 @@ const BankBad = resolveComponent('BankBad');
 const BankOk = resolveComponent('BankOk');
 const BankGreat = resolveComponent('BankGreat');
 
+const CUSTOM_BANKTAGS = [
+    'jpmorgan_chase',
+]
+
 const componentName = computed(() => {
+    const isCustomBankTag = CUSTOM_BANKTAGS.includes(router.currentRoute.value.params.bankTag as string);
+    
+    if (isCustomBankTag) {
+        // TODO: add custom component here
+    }
     const hasDetails = details.value && details.value.rating;
     if (!hasDetails)
         return undefined;
+
     switch (details.value.rating) {
         case "worst":
             return BankWorst;

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -14,23 +14,6 @@
         :fossilFreeAlliance="details.fossilFreeAlliance"
         :bankPage="bankPage"
     />
-    <!-- <BankWorst v-if="details.rating === 'worst'" :name="details.name" :subtitle="details.subtitle"
-        :website="details.website" :inheritBrandRating="details.inheritBrandRating" :header="details.header"
-        :summary="details.summary" :details="details.details" :amountFinancedSince2016="details.amountFinancedSince2016" />
-
-    <BankBad v-else-if="details.rating === 'bad'" :name="details.name" :subtitle="details.subtitle"
-        :website="details.website" :inheritBrandRating="details.inheritBrandRating" :header="details.header"
-        :summary="details.summary" :details="details.details" :amountFinancedSince2016="details.amountFinancedSince2016" />
-
-    <BankOk v-else-if="details.rating === 'ok'" :name="details.name" :subtitle="details.subtitle" :website="details.website"
-        :inheritBrandRating="details.inheritBrandRating" :header="details.header" :summary="details.summary" />
-
-    <BankGreat v-else-if="details.rating === 'great'" :name="details.name" :subtitle="details.subtitle"
-        :website="details.website" :inheritBrandRating="details.inheritBrandRating" :header="details.header"
-        :summary="details.summary" :fossilFreeAlliance="details.fossilFreeAlliance" />
-
-    <BankUnknown v-else :name="details.name" :subtitle="details.subtitle" :website="details.website"
-        :inheritBrandRating="details.inheritBrandRating" /> -->
 </template>
 
 <script setup lang="ts">
@@ -58,7 +41,6 @@ useHeadHelper(
 const { rating } = details.value;
 if (rating) useHeadRating(rating);
 
-// TODO: move to composable
 const BankUnknown = resolveComponent('BankUnknown');
 const BankWorst = resolveComponent('BankWorst');
 const BankBad = resolveComponent('BankBad');

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -2,7 +2,11 @@
     <!-- :summary, :header, :details, :amountFinancedSince2016 to be removed 
         https://linear.app/bankgreen/issue/PE-476/render-custom-bank-texts-from-prismic
     -->
-    <BankWorst v-if="details.rating === 'worst'" :name="details.name" :subtitle="details.subtitle"
+    <component v-if="componentName" :is="componentName"
+        :details="details"
+        :bankPage="bankPage"
+    />
+    <!-- <BankWorst v-if="details.rating === 'worst'" :name="details.name" :subtitle="details.subtitle"
         :website="details.website" :inheritBrandRating="details.inheritBrandRating" :header="details.header"
         :summary="details.summary" :details="details.details" :amountFinancedSince2016="details.amountFinancedSince2016" />
 
@@ -18,11 +22,12 @@
         :summary="details.summary" :fossilFreeAlliance="details.fossilFreeAlliance" />
 
     <BankUnknown v-else :name="details.name" :subtitle="details.subtitle" :website="details.website"
-        :inheritBrandRating="details.inheritBrandRating" />
+        :inheritBrandRating="details.inheritBrandRating" /> -->
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, computed } from "vue";
+import { useBankPage } from "../../utils/prismic/bankpage";
 
 // const route = useRoute()
 // FIXME this is a workaround for an upstream Vue router bug; when seeing this the next time,
@@ -33,6 +38,8 @@ const router = useRouter();
 const bankTag = router.currentRoute.value.params.bankTag;
 const details = ref(await getBankDetail(bankTag));
 
+const { bankPage } = await useBankPage(details);
+
 useHeadHelper(
     details.value?.name
         ? `${details.value.name}'s Climate Score - Bank.Green`
@@ -42,4 +49,30 @@ useHeadHelper(
 
 const { rating } = details.value;
 if (rating) useHeadRating(rating);
+
+// TODO: move to composable
+const BankUnknown = resolveComponent('BankUnknown');
+const BankWorst = resolveComponent('BankWorst');
+const BankBad = resolveComponent('BankBad');
+const BankOk = resolveComponent('BankOk');
+const BankGreat = resolveComponent('BankGreat');
+
+const componentName = computed(() => {
+    const hasDetails = details.value && details.value.rating;
+    if (!hasDetails)
+        return undefined;
+    switch (details.value.rating) {
+        case "worst":
+            return BankWorst;
+        case "bad":
+            return BankBad;
+        case "ok":
+            return BankOk;
+        case "great":
+            return BankGreat;
+        case "unknown":
+        default:
+            return BankUnknown;
+    }
+})
 </script>

--- a/utils/prismic/bankpage.js
+++ b/utils/prismic/bankpage.js
@@ -1,4 +1,9 @@
-function getBankPageId(bankDetails) {
+import CUSTOM_BANK_TAGS from '../../constants/customBankTags';
+
+function getBankPageId(bankTag, bankDetails) {
+    if (CUSTOM_BANK_TAGS.includes(bankTag))
+        return bankTag;
+
     const hasDetails = bankDetails && bankDetails.rating;
     if (!hasDetails)
         return undefined;
@@ -20,14 +25,14 @@ function getBankPageId(bankDetails) {
 }
 
 
-export async function useBankPage(bankDetails) {
+export async function useBankPage(bankTag, bankDetails) {
     const { client } = usePrismic();
 
     const bankPage = ref(null);
 
     try {
         const type = "bankpage";
-        const id = getBankPageId(unref(bankDetails));
+        const id = getBankPageId(bankTag, unref(bankDetails));
         if (typeof (id) === "string") {
             const { data } = await useAsyncData(id, () =>
                 client.getByUID(type, id)

--- a/utils/prismic/bankpage.js
+++ b/utils/prismic/bankpage.js
@@ -1,9 +1,4 @@
-import CUSTOM_BANK_TAGS from '../../constants/customBankTags';
-
-function getBankPageId(bankTag, bankDetails) {
-    if (CUSTOM_BANK_TAGS.includes(bankTag))
-        return bankTag;
-
+function getBankRating(bankDetails) {
     const hasDetails = bankDetails && bankDetails.rating;
     if (!hasDetails)
         return undefined;
@@ -27,17 +22,24 @@ function getBankPageId(bankTag, bankDetails) {
 
 export async function useBankPage(bankTag, bankDetails) {
     const { client } = usePrismic();
-
+    const type = "bankpage";
     const bankPage = ref(null);
 
     try {
-        const type = "bankpage";
-        const id = getBankPageId(bankTag, unref(bankDetails));
-        if (typeof (id) === "string") {
-            const { data } = await useAsyncData(id, () =>
-                client.getByUID(type, id)
-            );
-            bankPage.value = data.value;
+        const bankTagResponse = await useAsyncData(bankTag, () =>
+            client.getByUID(type, bankTag)
+        )
+        if (bankTagResponse.data.value) {
+            bankPage.value = bankTagResponse.data.value;
+        }
+        else {
+            const rating = getBankRating(unref(bankDetails));
+            if (typeof (rating) === "string") {
+                const { data } = await useAsyncData(rating, () =>
+                    client.getByUID(type, rating)
+                );
+                bankPage.value = data.value;
+            }
         }
     }
     catch (e) {

--- a/utils/prismic/bankpage.js
+++ b/utils/prismic/bankpage.js
@@ -19,6 +19,7 @@ function getBankPageId(bankDetails) {
     }
 }
 
+
 export async function useBankPage(bankDetails) {
     const { client } = usePrismic();
 
@@ -31,7 +32,7 @@ export async function useBankPage(bankDetails) {
             const { data } = await useAsyncData(id, () =>
                 client.getByUID(type, id)
             );
-            bankPage.value = data;
+            bankPage.value = data.value;
         }
     }
     catch (e) {

--- a/utils/prismic/bankpage.js
+++ b/utils/prismic/bankpage.js
@@ -1,0 +1,41 @@
+function getBankPageId(bankDetails) {
+    const hasDetails = bankDetails && bankDetails.rating;
+    if (!hasDetails)
+        return undefined;
+    const rating = !!(bankDetails && bankDetails.rating) ? bankDetails.rating : "";
+
+    switch (rating) {
+        case "worst":
+            return "worstbank";
+        case "bad":
+            return "badbank";
+        case "ok":
+            return "okbank";
+        case "great":
+            return "greatbank";
+        case "unknown":
+        default:
+            return "unknownbank";
+    }
+}
+
+export async function useBankPage(bankDetails) {
+    const { client } = usePrismic();
+
+    const bankPage = ref(null);
+
+    try {
+        const type = "bankpage";
+        const id = getBankPageId(unref(bankDetails));
+        if (typeof (id) === "string") {
+            const { data } = await useAsyncData(id, () =>
+                client.getByUID(type, id)
+            );
+            bankPage.value = data;
+        }
+    }
+    catch (e) {
+        console.log(e);
+    }
+    return { bankPage };
+}


### PR DESCRIPTION
- [x] Added field "Custom Subtitle" to CustomType bankPage 
![image](https://user-images.githubusercontent.com/3623903/230349976-34f82d32-07b8-4fbc-802b-07c6a8cc38df.png)

- [x] Added display logic for `data.subtitle` in all bank pages.
- [x] Refactor `[bankTag].vue` logic to retrieve  Prismic content on the page instead inside the component


I am not sure how to update our prismic at https://bankgreen.prismic.io/api/v2 so I cannot proceed to test the new field, but the styling as well as customtype setup should not have any problem

Do let me know if the naming/styling has any problem.
