### PR TITLE
Update submitContact logic

### DIFF
--- a/server/api/contact.post.js
+++ b/server/api/contact.post.js
@@ -5,8 +5,6 @@ export default defineEventHandler(async (event) => {
   }
   const headers = event.node.req.headers;
 
-  console.log(body, headers);
-
   const formatDate = (date) => {
     if (!date) return undefined;
     let newDate = new Date(date);
@@ -18,6 +16,7 @@ export default defineEventHandler(async (event) => {
   };
 
   const message = {
+    app_env: process.env.NODE_ENV || "production",
     first_name: body.firstName || "",
     last_name: body.lastName || "",
     email: body.email,

--- a/server/api/contact.post.js
+++ b/server/api/contact.post.js
@@ -58,7 +58,10 @@ export default defineEventHandler(async (event) => {
 });
   
 async function sendZapierContact(message) {
-  const hookUrl = "https://hooks.zapier.com/hooks/catch/9709339/ojsks1l";
+  const hookUrl = 
+    (message && message.tag === 'contact page form')
+    ? 'https://hooks.zapier.com/hooks/catch/9709339/ojsks1l'
+    : 'https://hooks.zapier.com/hooks/catch/9709339/ojskliq';
   await $fetch(hookUrl, { method: "POST", body: message });
 }
   

--- a/server/api/contact.post.js
+++ b/server/api/contact.post.js
@@ -1,0 +1,65 @@
+export default defineEventHandler(async (event) => {
+  let body = await readBody(event);
+  if (body instanceof Uint8Array) {
+    body = JSON.parse(new TextDecoder().decode(body));
+  }
+  const headers = event.node.req.headers;
+
+  console.log(body, headers);
+
+  const formatDate = (date) => {
+    if (!date) return undefined;
+    let newDate = new Date(date);
+    if (newDate) {
+      return newDate.toISOString().slice(0, 10);
+    } else {
+      return undefined;
+    }
+  };
+
+  const message = {
+    first_name: body.firstName || "",
+    last_name: body.lastName || "",
+    email: body.email,
+    created_at: new Date().getTime(),
+    message: body.message || "",
+    subject: body.subject || "",
+    tag: body.tag || "",
+    bank: body.bank || "",
+    website: body.website || "",
+    bank_display_name: body.bankDisplayName || "",
+    bank_name_when_not_found: body.bankNameWhenNotFound || "",
+    reminder: formatDate(body.reminder) || "",
+    dirty_deal_1: body.dirty_deal_1 || "",
+    dirty_deal_2: body.dirty_deal_2 || "",
+    rating: body.rating || "",
+    country: body.country || "",
+    is_agree_marketing: body.isAgreeMarketing || false,
+    path: body.path || "",
+    ip: headers["cf-connecting-ip"] || "",
+    location: {
+      country: headers["cf-ipcountry"] || "",
+      region: "",
+      city: headers["cf-ipcity"] || "",
+      cityLatLng: [
+        headers["cf-iplatitude"] || "",
+        headers["cf-iplongitude"] || "",
+      ],
+    },
+  };
+
+  await sendZapierContact(message);
+
+  // return {
+  //   message,
+  //   body,
+  //   headers,
+  // };
+  return "OK";
+});
+  
+async function sendZapierContact(message) {
+  const hookUrl = "https://hooks.zapier.com/hooks/catch/9709339/ojsks1l";
+  await $fetch(hookUrl, { method: "POST", body: message });
+}
+  

--- a/utils/contact.js
+++ b/utils/contact.js
@@ -1,6 +1,5 @@
 
-import { post } from "./backend";
-
-export function submitContact(form) {
-  return post("/submitContact", form);
+export async function submitContact(form) {
+  const response = await $fetch("/api/contact", { method: "POST", body: form });
+  return response;
 }


### PR DESCRIPTION
Now instead of calling backend method `/submitContact`, it calls Zapier webhook via a server post api method. Reason to create the post method is because we want to catch following Cloudflare's header values:
- cf-connecting-ip
- cf-ipcountry
- cf-ipcity
- cf-iplatitude
- cf-iplongitude

Since we have to deploy to test these above headers, for now I cannot verify if Zapier can receive them with the new logic flow

Also, new param `app_env` is added to form data in order to prepare for https://linear.app/bankgreen/issue/PE-550/trigger-zapiers-action-only-for-production-environment