### PR TITLE
Remove all references and usage of Django fields that have been migrated to Prismic

### DIFF
--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -1,7 +1,8 @@
 <template>
     <BankLayoutBadWorst>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" :prismicFieldSubtitle="bankPage?.data?.subtitle" />
+            <BankHeadline :name="name" :website="website" :inheritBrandRating="inheritBrandRating"
+                :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -13,47 +14,37 @@
                 <div class="flex justify-center md:block mb-8 w-full">
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="bankPage?.data.headline" />
+                    <PrismicRichText :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
-                    <div v-if="summary" v-html="summary"></div>
-                    <div v-else>Your bank doesn't top the charts, but it’s still using your money to lend to fossil fuel
-                        companies and projects that are rapidly accelerating the climate crisis.
-                    </div>
-                </div>  
+                    <PrismicRichText :field="bankPage?.data.description1" />
+                </div>
             </div>
         </template>
 
         <template #section2>
             <PrismicRichText v-if="bankPage?.data?.description2 && bankPage.data.description2.length > 0"
                 class="text-lg md:text-2xl whitespace-pre-line text-gray-900" :field="bankPage.data.description2" />
-            <div v-else-if="details" class="text-lg md:text-2xl whitespace-pre-line text-gray-900" v-html="details"></div>
             <p v-else class="text-lg md:text-2xl whitespace-pre-line text-gray-900" v-text="piggyText"></p>
         </template>
     </BankLayoutBadWorst>
 </template>
 
 
-<script setup lang="ts">import { PrismicDocument } from '@prismicio/types';
+<script setup lang="ts">
+import { PrismicDocument } from '@prismicio/types';
 
 const props = defineProps<{
     name: string,
     website: string,
-    subtitle: string,
-    header: string,
-    summary: string,
-    details: string
     inheritBrandRating: {
         name: string,
         tag: string
     },
-    amountFinancedSince2016: string,
     bankPage: PrismicDocument<Record<string, any>, string, string> | null,
 }>()
 
-const formattedTotal = computed(() => props.amountFinancedSince2016 ?? 'large amounts')
 
 const piggyText =
-    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about ${formattedTotal.value || "up to hundreds of billions of US dollars"} in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
+    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about large amounts in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
 </script>

--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -42,9 +42,9 @@ const props = defineProps<{
         tag: string
     },
     bankPage: PrismicDocument<Record<string, any>, string, string> | null,
+    amountFinancedSince2016: string
 }>()
 
-
 const piggyText =
-    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about large amounts in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
+    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about ${props.amountFinancedSince2016 ?? 'large amounts'} in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
 </script>

--- a/components/bank/BankGreat.vue
+++ b/components/bank/BankGreat.vue
@@ -1,7 +1,8 @@
 <template>
     <BankLayoutGreatOkUnknown>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating" :prismicFieldSubtitle="bankPage?.data?.subtitle" />
+            <BankHeadline :name="name" :website="website" :inheritBrandRating="inheritBrandRating"
+                :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -15,12 +16,10 @@
                         alt="Fossil Free Certification" />
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="bankPage?.data.headline" />
+                    <PrismicRichText :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
-                    <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else :field="bankPage?.data.description1" />
+                    <PrismicRichText :field="bankPage?.data.description1" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
@@ -72,14 +71,11 @@ import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
-    subtitle: string,
     inheritBrandRating: {
         tag: string,
         name: string
     },
     fossilFreeAlliance: boolean,
-    header: string,
-    summary: string,
     bankPage: PrismicDocument<Record<string, any>, string, string> | null,
 }>();
 </script>

--- a/components/bank/BankHeadline.vue
+++ b/components/bank/BankHeadline.vue
@@ -10,11 +10,9 @@
                 <h1 class="text-xl md:text-2xl text-gray-800 font-medium md:font-semibold tracking-wider flex items-center">
                     {{ name }}
                 </h1>
-                <div v-if="prismicFieldSubtitle"
-                    class="text-lg md:text-xl text-gray-500">
+                <div v-if="prismicFieldSubtitle" class="text-lg md:text-xl text-gray-500">
                     <PrismicRichText :field="prismicFieldSubtitle" />
                 </div>
-                <div v-else-if="subtitle" class="text-lg md:text-xl text-gray-500" v-html="subtitle"></div>
                 <div v-if="inheritBrandRating" class="text-xs text-gray-500">Deposits or policies controlled by
                     <NuxtLink class="underline" :to="`/banks/${inheritBrandRating.tag}`">{{
                         inheritBrandRating.name }}</NuxtLink>
@@ -33,14 +31,11 @@ import BankIcon from '@/components/forms/banks/BankIcon.vue'
 const props = defineProps({
     name: String,
     website: String,
-    subtitle: String,
     inheritBrandRating: {
         name: String,
         tag: String
     },
     prismicFieldSubtitle: undefined,
 })
-const bank = computed(() => props.details)
-
 
 </script>

--- a/components/bank/BankOk.vue
+++ b/components/bank/BankOk.vue
@@ -1,7 +1,8 @@
 <template>
     <BankLayoutGreatOkUnknown>
         <template #section1>
-            <BankHeadline :name="name" :website="website" :subtitle="subtitle" :inheritBrandRating="inheritBrandRating"  :prismicFieldSubtitle="bankPage?.data?.subtitle" />
+            <BankHeadline :name="name" :website="website" :inheritBrandRating="inheritBrandRating"
+                :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -12,12 +13,10 @@
             <div class="col-span-2 md:col-span-1">
                 <div class="flex justify-center md:block mb-8 w-full"></div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else :field="bankPage?.data.headline" />
+                    <PrismicRichText :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
-                    <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else :field="bankPage?.data.description1" />
+                    <PrismicRichText :field="bankPage?.data.description1" />
                 </div>
             </div>
             <div class="flex flex-col space-y-4 md:space-y-0 md:flex-row justify-center items-center">
@@ -66,13 +65,10 @@ import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
-    subtitle: string,
     inheritBrandRating: {
         tag: string,
         name: string
     },
-    header: string,
-    summary: string,
     bankPage: PrismicDocument<Record<string, any>, string, string> | null,
 }>()
 </script>

--- a/components/bank/BankUnknown.vue
+++ b/components/bank/BankUnknown.vue
@@ -1,8 +1,7 @@
 <template>
     <BankLayoutGreatOkUnknown>
         <template #section1>
-            <BankHeadline :name="name ?? 'Unknown Bank'" :website="website" :subtitle="subtitle"
-                :inheritBrandRating="inheritBrandRating" />
+            <BankHeadline :name="name ?? 'Unknown Bank'" :website="website" :inheritBrandRating="inheritBrandRating" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
                 <div class="flex flex-col items-center justify-start w-full">
@@ -71,7 +70,6 @@ import { PrismicDocument } from "@prismicio/types";
 const props = defineProps<{
     name: string,
     website: string,
-    subtitle: string,
     inheritBrandRating: {
         tag: string,
         name: string

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -39,9 +39,10 @@ const props = defineProps<{
         name: string,
         tag: string
     },
-    bankPage: PrismicDocument<Record<string, any>, string, string> | null
+    bankPage: PrismicDocument<Record<string, any>, string, string> | null,
+    amountFinancedSince2016: string,
 }>()
 
 const piggyText =
-    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about hundreds of millions to hundreds of billions of US dollars in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
+    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about ${props.amountFinancedSince2016 ?? 'large amounts'} in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
 </script>

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -1,11 +1,7 @@
 <template>
     <BankLayoutBadWorst>
         <template #section1>
-            <BankHeadline 
-                :name="name" 
-                :website="website" 
-                :subtitle="subtitle" 
-                :inheritBrandRating="inheritBrandRating"
+            <BankHeadline :name="name" :website="website" :inheritBrandRating="inheritBrandRating"
                 :prismicFieldSubtitle="bankPage?.data?.subtitle" />
             <div
                 class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center md:justify-start md:mt-8">
@@ -18,12 +14,10 @@
                 <div class="flex justify-center md:block mb-8 w-full">
                 </div>
                 <div class="font-semibold text-gray-800 text-2xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    <div v-if="header" v-html="header"></div>
-                    <PrismicRichText v-else-if="bankPage?.data" :field="bankPage?.data.headline" />
+                    <PrismicRichText v-if="bankPage?.data" :field="bankPage?.data.headline" />
                 </div>
                 <div class="prose sm:prose-lg xl:prose-xl prose-blurb">
-                    <div v-if="summary" v-html="summary"></div>
-                    <PrismicRichText v-else-if="bankPage?.data" :field="bankPage?.data.description1" />
+                    <PrismicRichText v-if="bankPage?.data" :field="bankPage?.data.description1" />
                 </div>
             </div>
         </template>
@@ -31,7 +25,6 @@
         <template #section2>
             <PrismicRichText v-if="bankPage?.data?.description2 && bankPage.data.description2.length > 0"
                 class="text-lg md:text-2xl whitespace-pre-line text-gray-900" :field="bankPage.data.description2" />
-            <div v-else-if="details" class="text-lg md:text-2xl whitespace-pre-line text-gray-900" v-html="details"></div>
             <p v-else class="text-lg md:text-2xl whitespace-pre-line text-gray-900" v-text="piggyText"></p>
         </template>
     </BankLayoutBadWorst>
@@ -42,20 +35,13 @@ import { PrismicDocument } from '@prismicio/types'
 const props = defineProps<{
     name: string,
     website: string,
-    subtitle: string,
-    header: string,
-    summary: string,
-    details: string
     inheritBrandRating: {
         name: string,
         tag: string
     },
-    amountFinancedSince2016: string,
     bankPage: PrismicDocument<Record<string, any>, string, string> | null
 }>()
 
-const formattedTotal = computed(() => props.amountFinancedSince2016 ?? 'large amounts')
-
 const piggyText =
-    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about ${formattedTotal.value || "hundreds of millions to hundreds of billions of US dollars"} in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
+    `While you’ve been stashing away money for a house or a weekend get-away, ${props.name} has been using your savings to lend to some very questionable fossil fuel friends.\n\nAnd it's not just a little here and there, we’re talking about hundreds of millions to hundreds of billions of US dollars in the 7 years since 197 countries agreed to drastically reduce their greenhouse gas emissions in the Paris Agreement.`
 </script>

--- a/components/eco-bank/EcoBankHeader.vue
+++ b/components/eco-bank/EcoBankHeader.vue
@@ -17,7 +17,7 @@
                         {{ `Our take on ${name}` }}
                     </div>
                     <div class="text-lg md:text-xl text-gray-500">
-                        <PrismicRichText v-if="prismicOurTake && prismicOurTake.length > 1" :field="prismicOurTake" />
+                        <PrismicRichText v-if="prismicOurTake && prismicOurTake.length > 0" :field="prismicOurTake" />
                         <span v-else-if="rating === 'ok'">This bank is ok</span>
                         <span v-else-if="rating === 'great'">This bank is great</span>
                     </div>

--- a/components/eco-bank/EcoBankHeader.vue
+++ b/components/eco-bank/EcoBankHeader.vue
@@ -1,58 +1,42 @@
 <template>
-<div class="page-fade-in contain">
-    <div class="relative bg-white rounded-xl shadow-soft border">
-        <div 
-            class="absolute -top-4 -right-4">
-            <img class="h-20 w-auto" src="/img/logos/bankgreen-logo.png" alt="Bank Green" />
-        </div>
-        <div class="grid grid-cols-2 gap-8 md:gap-10 py-12 px-8">
-            <EcoBankHeadline 
-                :name="name" 
-                :subtitle="subtitle" 
-                :website="website"
-                :inheritBrandRating="inheritBrandRating" 
-            />
-            <div class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center items-center">
-                <div class="flex flex-col items-center justify-start w-full">
-                    <BankCircle class="max-w-sm" :rating="rating" />
-                    <SocialSharer class="text-sushi-500" :hashtags="['climatecrisis', 'fossilbanks']" />
+    <div class="page-fade-in contain">
+        <div class="relative bg-white rounded-xl shadow-soft border">
+            <div class="absolute -top-4 -right-4">
+                <img class="h-20 w-auto" src="/img/logos/bankgreen-logo.png" alt="Bank Green" />
+            </div>
+            <div class="grid grid-cols-2 gap-8 md:gap-10 py-12 px-8">
+                <EcoBankHeadline :name="name" :website="website" :inheritBrandRating="inheritBrandRating" />
+                <div class="relative col-span-2 md:col-span-1 md:row-span-2 flex flex-row justify-center items-center">
+                    <div class="flex flex-col items-center justify-start w-full">
+                        <BankCircle class="max-w-sm" :rating="rating" />
+                        <SocialSharer class="text-sushi-500" :hashtags="['climatecrisis', 'fossilbanks']" />
+                    </div>
                 </div>
-            </div>  
-            <div class="col-span-2 md:col-span-1">
-                <div class="font-medium md:font-semibold text-gray-800 text-xl md:text-4xl tracking-wider mb-2 md:mb-6">
-                    {{ `Our take on ${name}` }}
-                </div>
-                <div class="text-lg md:text-xl text-gray-500">
-                    <PrismicRichText v-if="prismicOurTake && prismicOurTake.length > 1" :field="prismicOurTake" />
-                    <span v-else-if="ourTake" class="">{{
-                        ourTake
-                    }}</span>
-                    <span v-else-if="rating === 'ok'">This bank is ok</span>
-                    <span v-else-if="rating === 'great'">This bank is great</span>
-                </div>
-                <div class="flex flex-col md:flex-row justify-start items-center gap-6 mt-4" v-if="hasInstitutionCredentials">
-                    <template 
-                        v-for="cred in institutionCredentials"
-                    >
-                        <img v-if="isFossilFreeCertification(cred)"
-                            class="h-16 w-auto" 
-                            src="/img/certification/fossil-free-certified.png"
-                            :alt="cred?.name" 
-                        />
-                         
-                        <PrismicImage 
-                            v-else-if="cred?.prismicApiId &&
+                <div class="col-span-2 md:col-span-1">
+                    <div class="font-medium md:font-semibold text-gray-800 text-xl md:text-4xl tracking-wider mb-2 md:mb-6">
+                        {{ `Our take on ${name}` }}
+                    </div>
+                    <div class="text-lg md:text-xl text-gray-500">
+                        <PrismicRichText v-if="prismicOurTake && prismicOurTake.length > 1" :field="prismicOurTake" />
+                        <span v-else-if="rating === 'ok'">This bank is ok</span>
+                        <span v-else-if="rating === 'great'">This bank is great</span>
+                    </div>
+                    <div class="flex flex-col md:flex-row justify-start items-center gap-6 mt-4"
+                        v-if="hasInstitutionCredentials">
+                        <template v-for="cred in institutionCredentials">
+                            <img v-if="isFossilFreeCertification(cred)" class="h-16 w-auto"
+                                src="/img/certification/fossil-free-certified.png" :alt="cred?.name" />
+
+                            <PrismicImage v-else-if="cred?.prismicApiId &&
                                 prismicDefaultPageData &&
-                                prismicDefaultPageData[cred.prismicApiId]"
-                            class="h-16 md:h-12 w-auto"
-                            :field="prismicDefaultPageData[cred.prismicApiId]"
-                        />
-                    </template>
+                                prismicDefaultPageData[cred.prismicApiId]" class="h-16 md:h-12 w-auto"
+                                :field="prismicDefaultPageData[cred.prismicApiId]" />
+                        </template>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 </template>
 <script setup lang="ts">
 import { RichTextField } from "@prismicio/types";
@@ -69,19 +53,17 @@ const props = defineProps<{
         tag: string,
         name: string
     },
-    subtitle: string,
     rating: string,
-    ourTake: string,
     institutionCredentials: any[],
     prismicDefaultPageData: Record<string, any> | null,
     prismicOurTake?: RichTextField
 }>()
 
-const hasInstitutionCredentials : ComputedRef<boolean> = computed(() => 
+const hasInstitutionCredentials: ComputedRef<boolean> = computed(() =>
     props.institutionCredentials && props.institutionCredentials.length > 0)
 
 
-const isFossilFreeCertification = (institutionCredential : any) => {
+const isFossilFreeCertification = (institutionCredential: any) => {
     return (institutionCredential as InstitutionCredential).name == 'Fossil Free Certification'
 }
 </script>

--- a/components/eco-bank/EcoBankHeadline.vue
+++ b/components/eco-bank/EcoBankHeadline.vue
@@ -10,7 +10,6 @@
                 <h1 class="text-xl md:text-2xl text-gray-800 font-medium md:font-semibold tracking-wider flex items-center">
                     {{ name }}
                 </h1>
-                <div v-if="subtitle" class="text-lg md:text-xl text-gray-500" v-html="subtitle"></div>
                 <div v-if="inheritBrandRating" class="text-xs text-gray-500">Deposits or policies controlled by
                     <NuxtLink class="underline" :to="`/banks/${inheritBrandRating.tag}`">{{
                         inheritBrandRating.name }}</NuxtLink>
@@ -32,6 +31,5 @@ defineProps<{
         tag: string,
         name: string
     },
-    subtitle: string
 }>()
 </script>

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -1,19 +1,7 @@
 <template>
-    <!-- :summary, :header, :details, :amountFinancedSince2016 to be removed 
-        https://linear.app/bankgreen/issue/PE-476/render-custom-bank-texts-from-prismic
-    -->
-    <component v-if="details" :is="componentName"
-        :name="details.name" 
-        :subtitle="details.subtitle"
-        :website="details.website" 
-        :inheritBrandRating="details.inheritBrandRating" 
-        :header="details.header"
-        :summary="details.summary" 
-        :details="details.details" 
-        :amountFinancedSince2016="details.amountFinancedSince2016"
-        :fossilFreeAlliance="details.fossilFreeAlliance"
-        :bankPage="bankPage"
-    />
+    <component v-if="details" :is="componentName" :name="details.name" :website="details.website"
+        :inheritBrandRating="details.inheritBrandRating" :fossilFreeAlliance="details.fossilFreeAlliance"
+        :bankPage="bankPage" />
 </template>
 
 <script setup lang="ts">

--- a/pages/banks/[bankTag].vue
+++ b/pages/banks/[bankTag].vue
@@ -1,7 +1,7 @@
 <template>
     <component v-if="details" :is="componentName" :name="details.name" :website="details.website"
         :inheritBrandRating="details.inheritBrandRating" :fossilFreeAlliance="details.fossilFreeAlliance"
-        :bankPage="bankPage" />
+        :bankPage="bankPage" :amountFinancedSince2016="details.amountFinancedSince2016" />
 </template>
 
 <script setup lang="ts">

--- a/pages/sustainable-eco-banks/[bankTag].vue
+++ b/pages/sustainable-eco-banks/[bankTag].vue
@@ -1,49 +1,28 @@
 <template>
     <div class="page bg-sushi-50 space-y-8 md:space-y-24 pt-32 pb-16">
-        <EcoBankHeader
-            :name="details.name" 
-            :rating="details.rating" 
-            :subtitle="details.subtitle" 
-            :ourTake="details.ourTake"
-            :website="details.website" 
-            :inheritBrandRating="details.inheritBrandRating" 
-            :institutionCredentials="institutionCredentials"
-            :prismicOurTake="prismicPageData?.our_take"
-            :prismicDefaultPageData="prismicDefaultPageData"/>
+        <EcoBankHeader :name="details.name" :rating="details.rating" :website="details.website"
+            :inheritBrandRating="details.inheritBrandRating" :institutionCredentials="institutionCredentials"
+            :prismicOurTake="prismicPageData?.our_take" :prismicDefaultPageData="prismicDefaultPageData" />
 
 
-        <EcoBankSwitchSurvey
-            :bankName="details.name"
-            :prismicDefaultPageData="prismicDefaultPageData"
-            :website="details.website"
-        />
+        <EcoBankSwitchSurvey :bankName="details.name" :prismicDefaultPageData="prismicDefaultPageData"
+            :website="details.website" />
 
-        <EcoBankDetail 
-            :institutionType="institutionType"
-            :fromTheWebsite="details.fromTheWebsite" 
-            :name="details.name"
-            :website="details.website" 
-            :rating="details.rating" 
-            :bankFeatures="details.bankFeatures" 
-            :tag="details.tag" 
-            :prismicPageData="prismicPageData"
-            :prismicDefaultPageData="prismicDefaultPageData"
-        />
-        
-        <EcoBankSwitchSurvey
-            :bankName="details.name"
-            :prismicDefaultPageData="prismicDefaultPageData"
-            :website="details.website"
-        />
+        <EcoBankDetail :institutionType="institutionType" :fromTheWebsite="details.fromTheWebsite" :name="details.name"
+            :website="details.website" :rating="details.rating" :bankFeatures="details.bankFeatures" :tag="details.tag"
+            :prismicPageData="prismicPageData" :prismicDefaultPageData="prismicDefaultPageData" />
+
+        <EcoBankSwitchSurvey :bankName="details.name" :prismicDefaultPageData="prismicDefaultPageData"
+            :website="details.website" />
     </div>
 </template>
 
 <script setup lang="ts">
-const details : Ref<any | null> = ref(null);
-const prismicPageData : 
-    Ref<Record<string, any> | null> 
+const details: Ref<any | null> = ref(null);
+const prismicPageData:
+    Ref<Record<string, any> | null>
     = ref(null);
-const prismicDefaultPageData :
+const prismicDefaultPageData:
     Ref<Record<string, any> | null>
     = ref(null);
 
@@ -60,22 +39,22 @@ else {
 
     details.value = await getBankDetail(bankTag);
 
-    const prismicResponse = await useAsyncData(`sfipage`, () => 
+    const prismicResponse = await useAsyncData(`sfipage`, () =>
         client.getByUID("sfipage", bankTag)
     );
     prismicPageData.value = prismicResponse.data.value?.data || null;
-    const prismicDefaultDataResponse = await useAsyncData(`sfidefaults`, () => 
+    const prismicDefaultDataResponse = await useAsyncData(`sfidefaults`, () =>
         client.getByID('ZFpGfhEAACEAuFIf')
     );
     prismicDefaultPageData.value = prismicDefaultDataResponse.data.value?.data || null;
-    
+
     useHeadHelper(`${details.value.name} Review and Service Offering - Bank.Green`)
 }
 
-const institutionType : ComputedRef<string | undefined> = computed(() => {
-    const result = 
+const institutionType: ComputedRef<string | undefined> = computed(() => {
+    const result =
         (Array.isArray(details.value.commentary.institutionType) && details.value.commentary.institutionType.length)
-            ? details.value.commentary.institutionType[0].name 
+            ? details.value.commentary.institutionType[0].name
             : undefined;
     return result;
 });

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -20,13 +20,8 @@ const commentaryFields = `{
         name
     }
     fromTheWebsite,
-    ourTake,
     amountFinancedSince2016,
     fossilFreeAlliance,
-    subtitle,
-    header,
-    summary,
-    details,
     fossilFreeAllianceRating,
     showOnSustainableBanksPage
     institutionType {


### PR DESCRIPTION
This PR removes references to deprecated Django fields and ensures we only use the Prismic versions. It also changes the Prismic pull logic to ensure we display fields from a bank's prismic page if they're specified and use the defaults otherwise.
The branch is currently deployed at test.bank.green

I've tested this for banks in the website checklist and would be confident merging it, but @RogerTangos you might have a better sense for spot-checking some banks you know have interesting custom content?