### PR TITLE
PE-591 fixes

### DIFF
--- a/components/bank/BankGreat.vue
+++ b/components/bank/BankGreat.vue
@@ -34,7 +34,7 @@
                 <div class="contain">
                     <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                         <div class="md:w-1/2 max-w-sm">
-                            <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4"
+                            <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4 prose"
                                 :field="bankPage?.data.description2" />
                             <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                                 Our mission is to encourage as many people as possible to take a

--- a/components/bank/BankOk.vue
+++ b/components/bank/BankOk.vue
@@ -29,7 +29,7 @@
         <template #section2>
             <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                 <div class="md:w-1/2 max-w-sm">
-                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4" :field="bankPage?.data.description2" />
+                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4 prose" :field="bankPage?.data.description2" />
                     <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                         Our mission is to encourage as many people as possible to take a
                         stand - to refuse to let their money fuel environmental

--- a/components/bank/BankUnknown.vue
+++ b/components/bank/BankUnknown.vue
@@ -32,7 +32,7 @@
         <template #section2>
             <div class="flex flex-col md:flex-row items-center justify-center pt-8 pb-16">
                 <div class="md:w-1/2 max-w-sm">
-                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4" :field="bankPage?.data.description2" />
+                    <PrismicRichText class="text-lg md:text-2xl tracking-wide mb-4 prose" :field="bankPage?.data.description2" />
                     <p class="md:text-xl tracking-wide whitespace-pre-line text-gray-600 mb-12 md:mb-0">
                         Our mission is to encourage as many people as possible to take a
                         stand - to refuse to let their money fuel environmental

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -24,7 +24,7 @@
 
         <template #section2>
             <PrismicRichText v-if="bankPage?.data?.description2 && bankPage.data.description2.length > 0"
-                class="text-lg md:text-2xl whitespace-pre-line text-gray-900" :field="bankPage.data.description2" />
+                class="text-lg md:text-2xl whitespace-pre-line text-gray-900 prose" :field="bankPage.data.description2" />
             <p v-else class="text-lg md:text-2xl whitespace-pre-line text-gray-900" v-text="piggyText"></p>
         </template>
     </BankLayoutBadWorst>

--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="contain space-y-8 md:space-y-24">
+    <div class="contain space-y-8 md:space-y-16">
         <Tab :tabIds="['key-facts', 'products', 'fees']">
             <template v-slot:key-facts-nav>Key Facts</template>
             <template v-slot:products-nav>Products</template>
@@ -73,7 +73,7 @@
             <template v-slot:convenience-nav>Convenience</template>
             <template v-slot:impact>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <PrismicRichText class="pt-4 text-md md:text-lg tracking-wide space-y-6" :field="prismicPageData?.impact" />
+                    <PrismicRichText class="pt-12 text-md md:text-lg tracking-wide space-y-6" :field="prismicPageData?.impact" />
                     <div class=" order-first lg:order-last flex items-center justify-center">
                         <PrismicImage class="w-full md:w-3/4 mx-auto object-contain object-top"
                             v-if="prismicDefaultPageData && prismicDefaultPageData['impact-image']" alt="impact-image"
@@ -83,7 +83,7 @@
             </template>
             <template v-slot:security>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <PrismicRichText class="pt-4 text-md md:text-lg tracking-wide space-y-6"
+                    <PrismicRichText class="pt-12 text-md md:text-lg tracking-wide space-y-6"
                         :field="prismicPageData?.security" />
                     <div class=" order-first lg:order-last flex items-center justify-center">
                         <PrismicImage class="w-full md:w-3/4 mx-auto object-contain object-top"
@@ -94,7 +94,7 @@
             </template>
             <template v-slot:services>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <PrismicRichText class="pt-4 text-md md:text-lg tracking-wide space-y-6"
+                    <PrismicRichText class="pt-12 text-md md:text-lg tracking-wide space-y-6"
                         :field="prismicPageData?.services" />
                     <div class=" order-first lg:order-last flex items-center justify-center">
                         <PrismicImage class="w-full md:w-3/4 mx-auto object-contain object-top"
@@ -105,7 +105,7 @@
             </template>
             <template v-slot:convenience>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                    <PrismicRichText class="pt-4 text-md md:text-lg tracking-wide space-y-6"
+                    <PrismicRichText class="pt-12 text-md md:text-lg tracking-wide space-y-6"
                         :field="prismicPageData?.convenience" />
                     <div class=" order-first lg:order-last flex items-center justify-center">
                         <PrismicImage class="w-full md:w-3/4 mx-auto object-contain object-top"

--- a/components/eco-bank/EcoBankHeader.vue
+++ b/components/eco-bank/EcoBankHeader.vue
@@ -16,7 +16,7 @@
                     <div class="font-medium md:font-semibold text-gray-800 text-xl md:text-4xl tracking-wider mb-2 md:mb-6">
                         {{ `Our take on ${name}` }}
                     </div>
-                    <div class="text-lg md:text-xl text-gray-500">
+                    <div class="text-lg md:text-xl text-gray-500 prose">
                         <PrismicRichText v-if="prismicOurTake && prismicOurTake.length > 0" :field="prismicOurTake" />
                         <span v-else-if="rating === 'ok'">This bank is ok</span>
                         <span v-else-if="rating === 'great'">This bank is great</span>

--- a/components/eco-bank/EcoBankHeadline.vue
+++ b/components/eco-bank/EcoBankHeadline.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="relative col-span-2 md:col-span-1 flex items-end">
-        <div class="flex-1 flex items-center md:mt-8">
+    <div class="relative col-span-2 md:col-span-1 flex items-center md:-mt-8">
+        <div class="flex-1 flex items-center">
             <div class="relative w-14 h-14 mr-4 rounded-lg">
                 <ClearbitLogo v-if="website" :url="website" :size="24"
                     imgClass="absolute inset-0 z-20 bg-contain bg-no-repeat bg-center bg-white" />

--- a/pages/sustainable-eco-banks/[bankTag].vue
+++ b/pages/sustainable-eco-banks/[bankTag].vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="page bg-sushi-50 space-y-8 md:space-y-24 pt-32 pb-16">
+    <div class="page bg-sushi-50 space-y-8 md:space-y-16 pt-32 pb-16">
         <EcoBankHeader :name="details.name" :rating="details.rating" :website="details.website"
             :inheritBrandRating="details.inheritBrandRating" :institutionCredentials="institutionCredentials"
             :prismicOurTake="prismicPageData?.our_take" :prismicDefaultPageData="prismicDefaultPageData" />


### PR DESCRIPTION
- [x] Less white space before SFI name. 
- [ ] Fossil free alliance badge shows, i.e. on [beneficial_state_bank](https://bank.green/sustainable-eco-banks/beneficial_state_bank), which is a FFA member
- [x] Paragraph breaks in our-take are visible. e.g. [bank.green nationwide](https://bank.green/sustainable-eco-banks/nationwide) and [prismic nationwide our-take section](https://bankgreen.prismic.io/documents~w=nationwide&b=working&c=published&l=en-gb/ZFpH8BEAACAAuFln/)
- [x] Paragraph breaks in piggy text are visible. e.g. https://bank.green/banks/jpmorgan_chase/ 
- [x] Less white space at end of quantitative data section, centering the box if necessary.
- [ ] More uniformly cropped images in prismic
- [x] Double white space before first bullet (+ ~75 px)