### PR TITLE
Fix image size on pledge page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,9 @@
 {
-  "name": "nuxt-bank-green-fork",
+  "name": "nuxt-bank-green",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nuxt-bank-green",
       "hasInstallScript": true,
       "devDependencies": {
         "@gtm-support/vue-gtm": "^2.0.0",

--- a/pages/pledge.vue
+++ b/pages/pledge.vue
@@ -42,7 +42,7 @@
       </div>
       <NuxtImg
         src="/img/illustrations/pledge.png"
-        class="w-full"
+        class="md:w-2/5 max-w-full md:ml-24"
         loading="lazy"
         provider="none"
       />


### PR DESCRIPTION
Fixing the oversized image on /pledge page that breaks the page especially on mobile and overall doesn't look great on desktop either (see screenshot). 

<img width="1323" alt="Screenshot 2023-11-17 at 13 09 21" src="https://github.com/bank-green/nuxt-bank-green/assets/36188360/889b8a84-ba34-4406-ac29-5c11f9744149">
