### PR TITLE
Add email field and consent checkbox to one time donation

### DIFF
--- a/pages/donate.vue
+++ b/pages/donate.vue
@@ -96,11 +96,31 @@
                     </label>
                   </div>
                 </div>
-                <div
-                  id="stripe-payment-element"
-                  class="bg-gray-50 -mx-4 mt-12 px-6 py-8 rounded-xl"
-                  :class="!isStripeLoaded && 'hidden'"
-                />
+                <div class="flex flex-col gap-4 mt-12" :class="!isStripeLoaded && 'hidden'">
+                  <TextField
+                    v-model="email"
+                    name="email"
+                    type="email"
+                    :placeholder="'youremail@address.com'"
+                    :warning="warningsMap['email']"
+                    :dark="true"
+                    :required="false"
+                  />
+                  <CheckboxSection
+                    v-model="isAgreeMarketing"
+                    class="col-span-2"
+                    name="isAgreeMarketing"
+                    :warning="warningsMap['isAgreeMarketing']"
+                    :dark="true"
+                  >
+                    I wish to receive more information via email from
+                    Bank.Green.
+                  </CheckboxSection>
+                  <div
+                    id="stripe-payment-element"
+                    class="bg-gray-50 px-6 py-8 rounded-xl"
+                  />
+                </div>
                 <button
                   type="submit"
                   class="button-green w-full md:w-auto mt-12 flex justify-center"
@@ -120,6 +140,9 @@
   </div>
 </template>
 <script setup lang="ts">
+import TextField from '@/components/forms/TextField.vue'
+import CheckboxSection from '@/components/forms/CheckboxSection.vue'
+
 interface DonationOption<T> {
   label: string;
   value: T;
@@ -141,6 +164,12 @@ const donationOptions: DonationOption<number>[] = [
 
 const selectedMethod = ref<string>('one-time')
 const selectedAmount = ref<number | null>(null)
+const {
+  email,
+  warningsMap,
+  isAgreeMarketing,
+  send
+} = useContactForm('', ['email', 'bank', 'isAgreeTerms'], ref({}))
 
 const isOneTimePayment = computed(
   () => selectedMethod.value === 'one-time' && selectedAmount.value != null
@@ -194,7 +223,7 @@ watch(
 )
 
 const handleOneTimePayment = async () => {
-  if (selectedAmount.value == null) { /* empty */ } else if (isStripeLoaded.value) { handleSubmit() } else {
+  if (selectedAmount.value == null) { /* empty */ } else if (isStripeLoaded.value) { handleSubmit(isAgreeMarketing.value, email.value) } else {
     await initOneTimePayment(selectedAmount.value)
   }
 }
@@ -211,6 +240,7 @@ const handleRecurringPayment = async () => {
 
 const submit = () => {
   if (isOneTimePayment.value) {
+    send()
     handleOneTimePayment()
   } else if (isRecurring.value) {
     handleRecurringPayment()

--- a/pages/donate.vue
+++ b/pages/donate.vue
@@ -169,7 +169,7 @@ const {
   warningsMap,
   isAgreeMarketing,
   send
-} = useContactForm('', ['email', 'bank', 'isAgreeTerms'], ref({}))
+} = useContactForm('', ['email'], ref({}))
 
 const isOneTimePayment = computed(
   () => selectedMethod.value === 'one-time' && selectedAmount.value != null
@@ -240,7 +240,7 @@ const handleRecurringPayment = async () => {
 
 const submit = () => {
   if (isOneTimePayment.value) {
-    send()
+    if (email.value.length > 0) { send() }
     handleOneTimePayment()
   } else if (isRecurring.value) {
     handleRecurringPayment()

--- a/pages/donate.vue
+++ b/pages/donate.vue
@@ -96,7 +96,7 @@
                     </label>
                   </div>
                 </div>
-                <div class="flex flex-col gap-4 mt-12" :class="!isStripeLoaded && 'hidden'">
+                <div class="flex flex-col gap-4 mt-12 px-4" :class="!isStripeLoaded && 'hidden'">
                   <TextField
                     v-model="email"
                     name="email"

--- a/server/api/create-payment-intent.post.ts
+++ b/server/api/create-payment-intent.post.ts
@@ -27,6 +27,7 @@ export default defineEventHandler(
         }
       };
 
+      // we have to create the customer already on payment intent to link the payment to the customer to then update it later with email address
       const customer = await $fetch('https://api.stripe.com/v1/customers', {
         method: 'POST',
         headers: {

--- a/server/api/create-payment-intent.post.ts
+++ b/server/api/create-payment-intent.post.ts
@@ -22,15 +22,27 @@ export default defineEventHandler(
         return {
           success: false,
           clientSecret: null,
+          customerId: null,
           error: 'Invalid amount'
         }
-      }
+      };
+
+      const customer = await $fetch('https://api.stripe.com/v1/customers', {
+        method: 'POST',
+        headers: {
+          authorization: `Basic ${Buffer.from(stripeSecretKey + ':').toString(
+            'base64'
+          )}`
+        },
+        parseResponse: JSON.parse
+      })
 
       // we have to build the request ourself because the Stripe SDK does not play well with Cloudflare
       const reqBody = {
         amount: `${body.amount * DEFAULT_MULTIPLIER}`,
         currency: DEFAULT_CURRENCY,
-        'automatic_payment_methods[enabled]': 'true'
+        'automatic_payment_methods[enabled]': 'true',
+        customer: customer.id
       }
 
       const res = await $fetch('https://api.stripe.com/v1/payment_intents', {
@@ -47,6 +59,7 @@ export default defineEventHandler(
       return {
         success: true,
         clientSecret: res.client_secret,
+        customerId: customer.id,
         error: null
       }
     } catch (e) {
@@ -55,6 +68,7 @@ export default defineEventHandler(
       return {
         success: false,
         clientSecret: null,
+        customerId: null,
         error: _e.message
       }
     }

--- a/server/api/update-stripe-customer.post.ts
+++ b/server/api/update-stripe-customer.post.ts
@@ -1,0 +1,52 @@
+import { UpdateStripeCustomerResponse } from '~~/utils/interfaces/donate'
+
+const stripeSecretKey = useRuntimeConfig().STRIPE_SECRET_KEY as string
+
+export default defineEventHandler(
+  async (event): Promise<UpdateStripeCustomerResponse> => {
+    try {
+      let body = await readBody(event)
+      if (body instanceof Uint8Array) {
+        body = JSON.parse(new TextDecoder().decode(body))
+      }
+
+      if (body.email.length === 0) {
+        return {
+          success: false,
+          customerId: null,
+          error: 'Invalid amount'
+        }
+      }
+
+      const requBody = {
+        email: body.email,
+        description: `Consent for promotional emails: ${body.consent ? 'Yes' : 'No'}`
+      }
+
+      const customer = await $fetch(`https://api.stripe.com/v1/customers/${body.id}`, {
+        method: 'POST',
+        headers: {
+          authorization: `Basic ${Buffer.from(stripeSecretKey + ':').toString(
+            'base64'
+          )}`
+        },
+        body: new URLSearchParams(requBody),
+        parseResponse: JSON.parse
+      })
+
+      return {
+        success: true,
+        customerId: customer.id,
+        error: null
+      }
+    } catch (e) {
+      const _e: Error = e
+      setResponseStatus(400)
+      return {
+        success: false,
+        customerId: null,
+        error: _e.message
+      }
+    }
+  }
+)

--- a/server/api/update-stripe-customer.post.ts
+++ b/server/api/update-stripe-customer.post.ts
@@ -10,14 +10,6 @@ export default defineEventHandler(
         body = JSON.parse(new TextDecoder().decode(body))
       }
 
-      if (body.email.length === 0) {
-        return {
-          success: false,
-          customerId: null,
-          error: 'Invalid amount'
-        }
-      }
-
       const requBody = {
         email: body.email,
         // this is for now the only solution to note in Stripe whether we are allowed to send emails since there is no specific props on customers object for that

--- a/server/api/update-stripe-customer.post.ts
+++ b/server/api/update-stripe-customer.post.ts
@@ -20,6 +20,7 @@ export default defineEventHandler(
 
       const requBody = {
         email: body.email,
+        // this is for now the only solution to note in Stripe whether we are allowed to send emails since there is no specific props on customers object for that
         description: `Consent for promotional emails: ${body.consent ? 'Yes' : 'No'}`
       }
 

--- a/utils/interfaces/donate.ts
+++ b/utils/interfaces/donate.ts
@@ -11,5 +11,12 @@ export interface CreateSubscriptionResponse {
 export interface CreatePaymentIntentResponse {
   success: boolean;
   clientSecret: string | null;
+  customerId: string | null;
+  error: string | null;
+}
+
+export interface UpdateStripeCustomerResponse {
+  success: boolean;
+  customerId: string | null;
   error: string | null;
 }

--- a/utils/useStripe.ts
+++ b/utils/useStripe.ts
@@ -16,7 +16,7 @@ export default function useStripe (
 
   let stripe: Stripe | null = null
   let elements: StripeElements | null = null
-  let customerID: string | null = null
+  let customerId: string | null = null
 
   const initOneTimePayment = async (amount: number) => {
     isStripeLoaded.value = false
@@ -32,7 +32,7 @@ export default function useStripe (
     console.info(stripePaymentIntent)
     if (stripePaymentIntent?.clientSecret == null) { return }
 
-    customerID = stripePaymentIntent.customerId
+    customerId = stripePaymentIntent.customerId
 
     stripe = await loadStripe(publishableKey)
 
@@ -65,13 +65,11 @@ export default function useStripe (
         method: 'POST',
         body: {
           email,
-          id: customerID,
+          id: customerId,
           consent
         }
       }
     )
-
-    console.log({ customer: customer.customerId })
 
     if (customer.customerId && customer.customerId.length > 0) {
       const { error } = await stripe.confirmPayment({


### PR DESCRIPTION
### LInear ticket
https://linear.app/bankgreen/issue/EMB-31/add-email-address-field-into-stripe-payment

### General Notes

* The stripe payment element doesn't have a email field natively so we have to add it ourselves
* As requested by Albert, we want to store the email address and put on email list if consent. Hence there is also a consent checkbox added

### Customer logic:
* To link the customer to the payment confirmation, we need to create the customer already when creating the payment intent
* Since we have the email address and consent only later on, we have to update the customers on submission --> `update-stripe-customer` endpoint is created for that
* There is no consent props on the customers object, so I added it to the description you can see on the customer in Stripe

### How to test
* just submit a **one-time donation** and see if it arrives in stripe testing env with a linked customer, email address and description
* also test the case of not having email address nor consent (should be still possible as it is optional)

### Screenshot

<img width="448" alt="Screenshot 2023-12-01 at 18 44 02" src="https://github.com/bank-green/nuxt-bank-green/assets/36188360/27c8d3c1-961d-49ff-b4d2-b9bc36673903">
