### PR TITLE
Create new thanks page

### DIFF
--- a/components/Embrace.client.vue
+++ b/components/Embrace.client.vue
@@ -164,12 +164,13 @@ if (!embracePage?.value) {
 
 const hcaptchaSitekey = useRuntimeConfig().public.HAPTCHA_SITEKEY
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   name?: String;
-  // TODO: update to actual embrace thank you page (once we have one)
-  successRedirectURL?: { type: String, default: '/thanks' }
+  successRedirectURL: string
   embracePageProp?: PrismicDocument<Record<string, any>, string, string> | null;
-}>()
+}>(), {
+  successRedirectURL: '/thanks-embrace'
+})
 
 const fullName = ref<string>('')
 const fullNameWarning = ref<string | null>(null)

--- a/components/EmbraceModal.vue
+++ b/components/EmbraceModal.vue
@@ -72,10 +72,6 @@
           src="/img/icons/check.svg"
           alt=""
         >
-        <!-- TODO: sync embracePage to Prismic using SliceMachine once
-                   migrate hardcode/gpe page branches are merged and their
-                   custom types can be merged back to this branch (this is
-                   so we don't accidentally destroy any of that work). -->
         <span v-if="messageCopied">
           {{ embracePage?.data.copied_text_button_label || "Copied!" }}
         </span>
@@ -83,7 +79,7 @@
       <div
         class="self-stretch text-left text-slate-800 text-sm font-medium leading-6 tracking-wide mt-6 max-md:max-w-full"
       >
-        {{ embracePage?.data.footnote|| 'Please keep us (embrace@bank.green) in the BCC field of your email to help us keep track of messages sent.' }}
+        {{ embracePage?.data.preview_footnote|| 'Please keep us (embrace@bank.green) in the BCC field of your email to help us keep track of messages sent.' }}
       </div>
       <div class="grid grid-cols-2 items-center self-center flex w-full gap-5 mt-6 mb-6 max-md:max-w-full max-md:flex-wrap max-md:mt-8 max-md:mb-8">
         <button
@@ -98,7 +94,7 @@
           target="_blank"
           class="button-green"
           :class="{'pointer-events-none opacity-75': busy}"
-          @click.stop="emit('success')"
+          @click.prevent.stop="() => emit('success')"
         >
           <span class="font-semibold">
             {{ embracePage?.data.proceed_button_label || 'Go To Your Mail App' }}
@@ -110,6 +106,7 @@
 </template>
 
 <script setup lang="ts">
+import { PrismicDocument } from '@prismicio/types'
 import TextField from '@/components/forms/TextField.vue'
 import EmailPreviewField from '@/components/forms/EmailPreviewField.vue'
 
@@ -123,7 +120,18 @@ const { data: embracePage } = await useAsyncData('embrace', () =>
 const props = defineProps<{
   modelValue: boolean;
   message: string | null;
-  form: object;
+  form: {
+    fullName: string;
+    email: string;
+    subject: string;
+    bank: string | null;
+    bankEmail: string;
+    searchValue: string;
+    country: string;
+    hometown: string;
+    background: string;
+    body: string;
+};
   embracePageProp?: PrismicDocument<Record<string, any>, string, string> | null
 }>()
 

--- a/components/EmbraceModal.vue
+++ b/components/EmbraceModal.vue
@@ -94,7 +94,7 @@
           target="_blank"
           class="button-green"
           :class="{'pointer-events-none opacity-75': busy}"
-          @click.prevent.stop="() => emit('success')"
+          @click.stop="emit('success')"
         >
           <span class="font-semibold">
             {{ embracePage?.data.proceed_button_label || 'Go To Your Mail App' }}

--- a/pages/thanks-embrace.vue
+++ b/pages/thanks-embrace.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="page">
+    <div class="bg-white">
+      <div class="page-fade-in pt-28">
+        <SliceZone
+          v-if="thanksembrace?.data.slices"
+          :slices="thanksembrace?.data.slices ?? []"
+          :components="sliceComps"
+        />
+        <ThanksSection
+          v-else
+          title="Thank you!"
+          description="Your submission has been received."
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineSliceZoneComponents } from '@prismicio/vue'
+import { components } from '~~/slices'
+
+const sliceComps = ref(defineSliceZoneComponents(components))
+
+useHeadHelper('Thank you')
+const { client } = usePrismic()
+const { data: thanksembrace } = await useAsyncData('thanksembrace', () =>
+  client.getByUID('thankspages', 'thanks_embrace')
+)
+</script>


### PR DESCRIPTION
* Creating the thanks page for embrace after clicking the submit button. It's based on the newly created ThanksSlice. It's not exactly how the design looks but imo we should go with an aligned version as we have all the other thanks pages.
* The new ThanksPage document for embrace is already created in Prismic called `ThanksEmbrace`. You can test it via the Preview feature in Prismic
* The redirect after submit button is updated
* also fixed some types