### PR TITLE
feature/groot-124-add-seo-og-image-to-GPE-product-page

### DIFF
--- a/composables/useHeadHelpers.js
+++ b/composables/useHeadHelpers.js
@@ -1,4 +1,6 @@
-export const useHeadHelper = (title, description) => {
+import { asLink } from '@prismicio/helpers'
+
+export const useHeadHelper = (title, description, imageUrl) => {
   if (title) {
     useHead({
       title,
@@ -30,6 +32,29 @@ export const useHeadHelper = (title, description) => {
         {
           name: 'description',
           content: description
+        }
+      ]
+    })
+  }
+
+  if (imageUrl) {
+    useHead({
+      meta: [
+        {
+          property: 'og:image',
+          content: imageUrl
+        },
+        {
+          property: 'og:image:width',
+          content: '1665'
+        },
+        {
+          property: 'og:image:height',
+          content: '971'
+        },
+        {
+          property: 'twitter:image',
+          content: imageUrl
         }
       ]
     })
@@ -101,5 +126,5 @@ export const useHeadRating = (rating) => {
 
 export const usePrismicSEO = (data) => {
   if (!data) { return }
-  useHeadHelper(data.seo_title, data.seo_description)
+  useHeadHelper(data.seo_title, data.seo_description, asLink(data.seo_image))
 }

--- a/composables/useHeadHelpers.js
+++ b/composables/useHeadHelpers.js
@@ -46,11 +46,11 @@ export const useHeadHelper = (title, description, imageUrl) => {
         },
         {
           property: 'og:image:width',
-          content: '1665'
+          content: '1200'
         },
         {
           property: 'og:image:height',
-          content: '971'
+          content: '630'
         },
         {
           property: 'twitter:image',

--- a/customtypes/greenpolicyevaluatorpage/index.json
+++ b/customtypes/greenpolicyevaluatorpage/index.json
@@ -27,6 +27,10 @@
         "type": "Text",
         "config": { "label": "Seo Description", "placeholder": "" }
       },
+      "seo_image": {
+        "type": "Image",
+        "config": { "label": "SEO Image", "constraint": {}, "thumbnails": [] }
+      },
       "key_points_items": {
         "type": "Group",
         "config": {

--- a/pages/green-policy-evaluator.vue
+++ b/pages/green-policy-evaluator.vue
@@ -170,6 +170,8 @@ const { data: gpe } = await useAsyncData('gpe', () =>
 
 const ctaButtonClass = computed(() => ('button-green md:w-56 flex justify-center shadow-md font-bold'))
 
+usePrismicSEO(gpe.value?.data)
+
 // cal.com embed code used within CalModal
 useHead({
   script: [

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1292,6 +1292,17 @@ interface GreenpolicyevaluatorpageDocumentData {
   seo_description: prismic.KeyTextField;
 
   /**
+   * SEO Image field in *GreenPolicyEvaluatorPage*
+   *
+   * - **Field Type**: Image
+   * - **Placeholder**: *None*
+   * - **API ID Path**: greenpolicyevaluatorpage.seo_image
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#image
+   */
+  seo_image: prismic.ImageField<never>;
+
+  /**
    * Key Points Items field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Group


### PR DESCRIPTION
* for better SEO and UX when Zak is sharing the new GPE product page, Ive added the option to also change the og:image and twitter:image on each page within the useHeadHelpers and also the usePrismicSEO 
* I added a SEO image to prismic for GPE page