### PR TITLE
Feature/groot 110 adjust thank you page

### DIFF
--- a/components/thanks/ThanksSection.vue
+++ b/components/thanks/ThanksSection.vue
@@ -26,18 +26,18 @@
 
       <h1
         v-if="title"
-        class="mt-8 text-2xl font-semibold whitespace-pre-line mb-8"
+        class="mt-8 text-4xl font-semibold whitespace-pre-line mb-8"
       >
         {{ title }}
       </h1>
 
-      <p v-if="description" class="text-gray-700 px-4 max-w-lg mx-auto">
+      <p v-if="description" class="text-gray-700 px-4 max-w-lg mx-auto text-xl">
         {{ description }}
       </p>
     </div>
   </div>
-  <Swoosh direction="up" color="text-sushi-100" />
-  <div class="relative py-8 sm:py-16 bg-sushi-100">
+  <Swoosh v-if="getSliceBoolean(showExploreSection)" direction="up" color="text-sushi-100" />
+  <div v-if="getSliceBoolean(showExploreSection)" class="relative py-8 sm:py-16 bg-sushi-100">
     <div class="contain sm:text-center">
       <h4
         class="font-semibold text-xl text-gray-800 mb-6 sm:text-2xl tracking-wide"
@@ -54,8 +54,15 @@
 </template>
 
 <script setup lang="ts">
-defineProps({
-  title: String,
-  description: String
-})
+import { getSliceBoolean } from '@/utils/prismic/conversions'
+
+withDefaults(defineProps<{
+    title: string,
+    description: string,
+    showExploreSection?: boolean | null
+  }>(),
+{
+  showExploreSection: true
+}
+)
 </script>

--- a/customtypes/greenpolicyevaluatorpage/index.json
+++ b/customtypes/greenpolicyevaluatorpage/index.json
@@ -27,6 +27,10 @@
         "type": "Text",
         "config": { "label": "Seo Description", "placeholder": "" }
       },
+      "seo_image": {
+        "type": "Image",
+        "config": { "label": "SEO image", "constraint": {}, "thumbnails": [] }
+      },
       "key_points_items": {
         "type": "Group",
         "config": {

--- a/pages/thanks-embrace.vue
+++ b/pages/thanks-embrace.vue
@@ -7,6 +7,12 @@
           :slices="thanksembrace?.data.slices ?? []"
           :components="sliceComps"
         />
+        <ThanksSection
+          v-else
+          title="Thank you!"
+          description="Your submission has been received."
+          :show-explore-section="false"
+        />
         <Swoosh direction="up" color="text-sushi-50" />
         <Donation class="bg-sushi-50" />
       </div>

--- a/pages/thanks-embrace.vue
+++ b/pages/thanks-embrace.vue
@@ -7,11 +7,8 @@
           :slices="thanksembrace?.data.slices ?? []"
           :components="sliceComps"
         />
-        <ThanksSection
-          v-else
-          title="Thank you!"
-          description="Your submission has been received."
-        />
+        <Swoosh direction="up" color="text-sushi-50" />
+        <Donation class="bg-sushi-50" />
       </div>
     </div>
   </div>

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -676,8 +676,7 @@ interface EcobankspageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
-  slices: prismic.SliceZone<EcobankspageDocumentDataSlicesSlice>
-  /**
+  slices: prismic.SliceZone<EcobankspageDocumentDataSlicesSlice> /**
    * Slice Zone field in *EcoBanksPage*
    *
    * - **Field Type**: Slice Zone
@@ -773,8 +772,7 @@ interface EmbracepageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  seo_description: prismic.KeyTextField
-  /**
+  seo_description: prismic.KeyTextField /**
    * Preview Title field in *EmbracePage*
    *
    * - **Field Type**: Text
@@ -871,8 +869,7 @@ interface EmbracepageDocumentData {
    * - **Tab**: Preview
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  bcc_email: prismic.KeyTextField
-  /**
+  bcc_email: prismic.KeyTextField /**
    * Form Title field in *EmbracePage*
    *
    * - **Field Type**: Text
@@ -1314,6 +1311,17 @@ interface GreenpolicyevaluatorpageDocumentData {
   seo_description: prismic.KeyTextField;
 
   /**
+   * SEO image field in *GreenPolicyEvaluatorPage*
+   *
+   * - **Field Type**: Image
+   * - **Placeholder**: *None*
+   * - **API ID Path**: greenpolicyevaluatorpage.seo_image
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#image
+   */
+  seo_image: prismic.ImageField<never>;
+
+  /**
    * Key Points Items field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Group
@@ -1357,8 +1365,7 @@ interface GreenpolicyevaluatorpageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
-  slices: prismic.SliceZone<GreenpolicyevaluatorpageDocumentDataSlicesSlice>
-  /**
+  slices: prismic.SliceZone<GreenpolicyevaluatorpageDocumentDataSlicesSlice> /**
    * Title_as_featured_in field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Text
@@ -1378,8 +1385,7 @@ interface GreenpolicyevaluatorpageDocumentData {
    * - **Tab**: As Featured In
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
-  slices1: prismic.SliceZone<GreenpolicyevaluatorpageDocumentDataSlices1Slice>
-  /**
+  slices1: prismic.SliceZone<GreenpolicyevaluatorpageDocumentDataSlices1Slice> /**
    * Title_Features field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Text
@@ -1423,8 +1429,7 @@ interface GreenpolicyevaluatorpageDocumentData {
    * - **Tab**: Features
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  description_features_2: prismic.KeyTextField
-  /**
+  description_features_2: prismic.KeyTextField /**
    * Title_USP field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Text
@@ -1446,8 +1451,7 @@ interface GreenpolicyevaluatorpageDocumentData {
    */
   usp_items: prismic.GroupField<
     Simplify<GreenpolicyevaluatorpageDocumentDataUspItemsItem>
-  >
-  /**
+  > /**
    * Title_CTA field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Text
@@ -1467,8 +1471,7 @@ interface GreenpolicyevaluatorpageDocumentData {
    * - **Tab**: CTA
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  description_cta: prismic.KeyTextField
-  /**
+  description_cta: prismic.KeyTextField /**
    * Title_FAQ field in *GreenPolicyEvaluatorPage*
    *
    * - **Field Type**: Text
@@ -1577,8 +1580,7 @@ interface HomepageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  seo_description: prismic.KeyTextField
-  /**
+  seo_description: prismic.KeyTextField /**
    * Slice Zone field in *HomePage*
    *
    * - **Field Type**: Slice Zone
@@ -2256,8 +2258,7 @@ interface TakeactionpageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#key-text
    */
-  seo_description: prismic.KeyTextField
-  /**
+  seo_description: prismic.KeyTextField /**
    * Slice Zone field in *TakeActionPage*
    *
    * - **Field Type**: Slice Zone
@@ -2266,8 +2267,7 @@ interface TakeactionpageDocumentData {
    * - **Tab**: Pressure
    * - **Documentation**: https://prismic.io/docs/field#slices
    */;
-  slices1: prismic.SliceZone<TakeactionpageDocumentDataSlices1Slice>
-  /**
+  slices1: prismic.SliceZone<TakeactionpageDocumentDataSlices1Slice> /**
    * Slice Zone field in *TakeActionPage*
    *
    * - **Field Type**: Slice Zone
@@ -2276,8 +2276,7 @@ interface TakeactionpageDocumentData {
    * - **Tab**: Switch
    * - **Documentation**: https://prismic.io/docs/field#slices
    */;
-  slices2: prismic.SliceZone<TakeactionpageDocumentDataSlices2Slice>
-  /**
+  slices2: prismic.SliceZone<TakeactionpageDocumentDataSlices2Slice> /**
    * Slice Zone field in *TakeActionPage*
    *
    * - **Field Type**: Slice Zone
@@ -2286,8 +2285,7 @@ interface TakeactionpageDocumentData {
    * - **Tab**: Share
    * - **Documentation**: https://prismic.io/docs/field#slices
    */;
-  slices3: prismic.SliceZone<TakeactionpageDocumentDataSlices3Slice>
-  /**
+  slices3: prismic.SliceZone<TakeactionpageDocumentDataSlices3Slice> /**
    * Slice Zone field in *TakeActionPage*
    *
    * - **Field Type**: Slice Zone
@@ -2354,8 +2352,7 @@ interface TeampageDocumentData {
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#slices
    */
-  slices: prismic.SliceZone<TeampageDocumentDataSlicesSlice>
-  /**
+  slices: prismic.SliceZone<TeampageDocumentDataSlicesSlice> /**
    * Slice Zone field in *TeamPage*
    *
    * - **Field Type**: Slice Zone
@@ -3249,6 +3246,17 @@ export interface ThanksSliceSliceDefaultPrimary {
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
   description: prismic.RichTextField;
+
+  /**
+   * show explore section field in *ThanksSlice → Primary*
+   *
+   * - **Field Type**: Boolean
+   * - **Placeholder**: *None*
+   * - **Default Value**: true
+   * - **API ID Path**: thanks_slice.primary.show_explore_section
+   * - **Documentation**: https://prismic.io/docs/field#boolean
+   */
+  show_explore_section: prismic.BooleanField;
 }
 
 /**
@@ -3285,7 +3293,7 @@ declare module "@prismicio/client" {
   interface CreateClient {
     (
       repositoryNameOrEndpoint: string,
-      options?: prismic.ClientConfig
+      options?: prismic.ClientConfig,
     ): prismic.Client<AllDocumentTypes>;
   }
 
@@ -3293,38 +3301,56 @@ declare module "@prismicio/client" {
     export type {
       AccordionitemDocument,
       AccordionitemDocumentData,
+      AccordionitemDocumentDataSlicesSlice,
       BankpageDocument,
       BankpageDocumentData,
+      BankpageDocumentDataSlicesSlice,
       BlogpostDocument,
       BlogpostDocumentData,
+      BlogpostDocumentDataSlicesSlice,
       CalltoactionDocument,
       CalltoactionDocumentData,
       CertificationpageDocument,
       CertificationpageDocumentData,
+      CertificationpageDocumentDataSlicesSlice,
       ContactpageDocument,
       ContactpageDocumentData,
       DisclaimerpageDocument,
       DisclaimerpageDocumentData,
+      DisclaimerpageDocumentDataSlicesSlice,
       DonationpageDocument,
       DonationpageDocumentData,
       EcobankspageDocument,
       EcobankspageDocumentData,
+      EcobankspageDocumentDataSlicesSlice,
+      EcobankspageDocumentDataSlices1Slice,
       EmbracepageDocument,
       EmbracepageDocumentData,
       FaqpageDocument,
       FaqpageDocumentData,
+      FaqpageDocumentDataSlicesSlice,
       GreenpolicyevaluatorpageDocument,
       GreenpolicyevaluatorpageDocumentData,
+      GreenpolicyevaluatorpageDocumentDataKeyPointsItemsItem,
+      GreenpolicyevaluatorpageDocumentDataSlicesSlice,
+      GreenpolicyevaluatorpageDocumentDataSlices1Slice,
+      GreenpolicyevaluatorpageDocumentDataFeaturesItemsItem,
+      GreenpolicyevaluatorpageDocumentDataUspItemsItem,
+      GreenpolicyevaluatorpageDocumentDataSlices5Slice,
       HomepageDocument,
       HomepageDocumentData,
+      HomepageDocumentDataSlices1Slice,
       PledgepageDocument,
       PledgepageDocumentData,
       PresspageDocument,
       PresspageDocumentData,
+      PresspageDocumentDataSlicesSlice,
       PresspostDocument,
       PresspostDocumentData,
+      PresspostDocumentDataSlicesSlice,
       PrivacypageDocument,
       PrivacypageDocumentData,
+      PrivacypageDocumentDataSlicesSlice,
       SfiPageDocument,
       SfiPageDocumentData,
       SfipageDocument,
@@ -3333,47 +3359,67 @@ declare module "@prismicio/client" {
       SwitchsurveyexitDocumentData,
       TakeactionpageDocument,
       TakeactionpageDocumentData,
+      TakeactionpageDocumentDataSlices1Slice,
+      TakeactionpageDocumentDataSlices2Slice,
+      TakeactionpageDocumentDataSlices3Slice,
+      TakeactionpageDocumentDataSlices4Slice,
       TeampageDocument,
       TeampageDocumentData,
+      TeampageDocumentDataSlicesSlice,
+      TeampageDocumentDataSlices1Slice,
       TextonlypagesDocument,
       TextonlypagesDocumentData,
       ThankspagesDocument,
       ThankspagesDocumentData,
+      ThankspagesDocumentDataSlicesSlice,
       ThankspledgeDocument,
       ThankspledgeDocumentData,
+      ThankspledgeDocumentDataSlicesSlice,
       VolunteerspageDocument,
       VolunteerspageDocumentData,
+      VolunteerspageDocumentDataSlicesSlice,
       AllDocumentTypes,
       AccordionSliceSlice,
+      AccordionSliceSliceRichTextPrimary,
+      AccordionSliceSliceRichTextWithStepPrimary,
+      AccordionSliceSliceDefaultPrimary,
       AccordionSliceSliceVariation,
       AccordionSliceSliceRichText,
       AccordionSliceSliceRichTextWithStep,
       AccordionSliceSliceDefault,
       ButtonSliceSlice,
+      ButtonSliceSliceDefaultPrimary,
       ButtonSliceSliceVariation,
       ButtonSliceSliceDefault,
       EmbedSliceSlice,
+      EmbedSliceSliceDefaultPrimary,
       EmbedSliceSliceVariation,
       EmbedSliceSliceDefault,
       FeaturedInSliceSlice,
+      FeaturedInSliceSliceDefaultPrimary,
       FeaturedInSliceSliceVariation,
       FeaturedInSliceSliceDefault,
       ImageSliceSlice,
+      ImageSliceSliceDefaultPrimary,
       ImageSliceSliceVariation,
       ImageSliceSliceDefault,
       SharePicGallerySliceSlice,
       SharePicGallerySliceSliceVariation,
       SharePicGallerySliceSliceDefault,
       SocialSharerSliceSlice,
+      SocialSharerSliceSliceDefaultPrimary,
       SocialSharerSliceSliceVariation,
       SocialSharerSliceSliceDefault,
       TeamMemberSliceSlice,
+      TeamMemberSliceSliceDefaultPrimary,
       TeamMemberSliceSliceVariation,
       TeamMemberSliceSliceDefault,
       TextSliceSlice,
+      TextSliceSliceDefaultPrimary,
       TextSliceSliceVariation,
       TextSliceSliceDefault,
       ThanksSliceSlice,
+      ThanksSliceSliceDefaultPrimary,
       ThanksSliceSliceVariation,
       ThanksSliceSliceDefault,
     };

--- a/slices/ThanksSlice/index.vue
+++ b/slices/ThanksSlice/index.vue
@@ -2,6 +2,7 @@
   <ThanksSection
     :title="asText(slice?.primary.title)!"
     :description="asText(slice?.primary.description)!"
+    :show-explore-section="slice?.primary.show_explore_section"
   />
 </template>
 

--- a/slices/ThanksSlice/mocks.json
+++ b/slices/ThanksSlice/mocks.json
@@ -24,6 +24,10 @@
 						}
 					}
 				]
+			},
+			"show_explore_section": {
+				"__TYPE__": "BooleanContent",
+				"value": true
 			}
 		},
 		"items": []

--- a/slices/ThanksSlice/model.json
+++ b/slices/ThanksSlice/model.json
@@ -1,38 +1,46 @@
 {
-    "id": "thanks_slice",
-    "type": "SharedSlice",
-    "name": "ThanksSlice",
-    "description": "ThanksSlice",
-    "variations": [
-      {
-        "id": "default",
-        "name": "Default",
-        "docURL": "...",
-        "version": "initial",
-        "description": "Default",
-        "imageUrl": "",
-        "primary": {
-          "title": {
-            "type": "StructuredText",
-            "config": {
-              "label": "title",
-              "placeholder": "",
-              "allowTargetBlank": true,
-              "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
-            }
-          },
-          "description": {
-            "type": "StructuredText",
-            "config": {
-              "label": "description",
-              "placeholder": "",
-              "allowTargetBlank": true,
-              "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
-            }
+  "id": "thanks_slice",
+  "type": "SharedSlice",
+  "name": "ThanksSlice",
+  "description": "ThanksSlice",
+  "variations": [
+    {
+      "id": "default",
+      "name": "Default",
+      "docURL": "...",
+      "version": "initial",
+      "description": "Default",
+      "imageUrl": "",
+      "primary": {
+        "title": {
+          "type": "StructuredText",
+          "config": {
+            "label": "title",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
           }
         },
-        "items": {}
-      }
-    ]
-  }
-  
+        "description": {
+          "type": "StructuredText",
+          "config": {
+            "label": "description",
+            "placeholder": "",
+            "allowTargetBlank": true,
+            "single": "paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl"
+          }
+        },
+        "show_explore_section": {
+          "type": "Boolean",
+          "config": {
+            "label": "show explore section",
+            "placeholder_false": "false",
+            "placeholder_true": "true",
+            "default_value": true
+          }
+        }
+      },
+      "items": {}
+    }
+  ]
+}

--- a/utils/prismic/conversions.ts
+++ b/utils/prismic/conversions.ts
@@ -1,0 +1,5 @@
+// There is an issue with Prismic and Slice machine where the boolean field default value is not set and it's just null
+// This function can be used to convert to a proper boolean
+export const getSliceBoolean = (value: boolean | null) => {
+  return value === null ? true : value
+}


### PR DESCRIPTION
* Added a new field called `show_explore_section` to the ´ThanksSlice´ so that you can choose via Prismice whether you want the explore banks section shown or not. This makes it more dynamic for different thanks sections
* Added a helper function to convert the prismic boolean to always a proper boolean. This is a known issue from Prismic and slicemachine that if the boolean field is not used yet, it sets the value to `null`, even though a default value of `true` is set. They're on it to fix it but this is now an in between solution
* Added the Donation section to the` /thanks-embrace` page