### PR TITLE
fix GROOT-155: description 2 text not showing

### DIFF
--- a/components/bank/BankBad.vue
+++ b/components/bank/BankBad.vue
@@ -34,7 +34,7 @@
     <template #section2>
       <PrismicRichText
         v-if="
-          bankPage?.data?.description2 && bankPage.data.description2.length > 0
+          bankPage?.data?.description2 && isEmptyPrismicField(bankPage?.data.description2)
         "
         class="text-lg md:text-2xl whitespace-pre-line text-gray-900 prose"
         :field="bankPage.data.description2"
@@ -50,6 +50,7 @@
 
 <script setup lang="ts">
 import { PrismicDocument } from '@prismicio/types'
+import isEmptyPrismicField from '~/utils/prismic/isEmptyPrismicField'
 
 const props = defineProps<{
   name: string;

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -40,7 +40,7 @@
     <template #section2>
       <PrismicRichText
         v-if="
-          bankPage?.data.description2 && !isEmptyPrismicField(bankPage?.data.description2)
+          bankPage?.data?.description2 && !isEmptyPrismicField(bankPage?.data.description2)
         "
         class="text-lg md:text-2xl whitespace-pre-line text-gray-900 prose"
         :field="bankPage.data.description2"

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -39,7 +39,9 @@
 
     <template #section2>
       <PrismicRichText
-        v-if="!!bankPage?.data.description2 && !isEmptyPrismicField(bankPage?.data.description2)"
+        v-if="
+          bankPage?.data.description2 && !isEmptyPrismicField(bankPage?.data.description2)
+        "
         class="text-lg md:text-2xl whitespace-pre-line text-gray-900 prose"
         :field="bankPage.data.description2"
       />

--- a/components/bank/BankWorst.vue
+++ b/components/bank/BankWorst.vue
@@ -39,9 +39,7 @@
 
     <template #section2>
       <PrismicRichText
-        v-if="
-          bankPage?.data?.description2 && bankPage.data.description2.length > 0
-        "
+        v-if="!!bankPage?.data.description2 && !isEmptyPrismicField(bankPage?.data.description2)"
         class="text-lg md:text-2xl whitespace-pre-line text-gray-900 prose"
         :field="bankPage.data.description2"
       />
@@ -55,6 +53,7 @@
 </template>
 <script setup lang="ts">
 import { PrismicDocument } from '@prismicio/types'
+import isEmptyPrismicField from '~/utils/prismic/isEmptyPrismicField'
 
 const props = defineProps<{
   name: string;

--- a/utils/prismic/isEmptyPrismicField.ts
+++ b/utils/prismic/isEmptyPrismicField.ts
@@ -1,0 +1,27 @@
+/**
+ * An util function to check for empty Prismic field, regardless of types
+ */
+import { RTEmbedNode, RTImageNode, RTNode, RTTextNode, RichTextNodeType } from '@prismicio/types';
+
+function isRTNode (nodeObj: any): nodeObj is RTNode {
+  return 'type' in nodeObj
+}
+function isEmptyRTNode (nodeObj: RTNode): boolean {
+  return (nodeObj.type === RichTextNodeType.image && (nodeObj as RTImageNode).url.length > 0) ||
+    (nodeObj.type === RichTextNodeType.embed && !!(nodeObj as RTEmbedNode).oembed) ||
+    (nodeObj as RTTextNode).text.length > 0
+}
+
+export default function (fieldData: any): boolean {
+  const isTextField = typeof fieldData === 'string'
+  if (isTextField) {
+    return fieldData.length === 0
+  }
+  const isRichTextField = Array.isArray(fieldData) && fieldData.every(isRTNode)
+  if (isRichTextField) {
+    return (
+      fieldData.length > 0 && fieldData.some(node => !isEmptyRTNode(node))
+    )
+  }
+  return false
+}

--- a/utils/prismic/isEmptyPrismicField.ts
+++ b/utils/prismic/isEmptyPrismicField.ts
@@ -1,7 +1,7 @@
 /**
  * An util function to check for empty Prismic field, regardless of types
  */
-import { RTEmbedNode, RTImageNode, RTNode, RTTextNode, RichTextNodeType } from '@prismicio/types';
+import { RTEmbedNode, RTImageNode, RTNode, RTTextNode, RichTextNodeType } from '@prismicio/types'
 
 function isRTNode (nodeObj: any): nodeObj is RTNode {
   return 'type' in nodeObj
@@ -20,8 +20,8 @@ export default function (fieldData: any): boolean {
   const isRichTextField = Array.isArray(fieldData) && fieldData.every(isRTNode)
   if (isRichTextField) {
     return (
-      fieldData.length > 0 && fieldData.some(node => !isEmptyRTNode(node))
+      fieldData.length === 0 || fieldData.every(node => !isEmptyRTNode(node))
     )
   }
-  return false
+  return true
 }


### PR DESCRIPTION
Problem: old condition to check for empty Prismic field is not suitable for rich text format.
Solution: add utils function `utils/prismic/isEmptyPrismicField.ts` to generalize logic to check for empty Prismic fields.
