### PR TITLE
Albert/groot 131 add fromthewebsite to sfi page

### DIFF
--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -132,7 +132,7 @@
         Business current accounts
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Business Savings Accounts']"
+        v-model="filterPayload.bankAccounts['Business savings accounts']"
         class="col-span-full"
         name="Business Savings Accounts"
       >
@@ -146,7 +146,7 @@
         Small business lending
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Small business lending']"
+        v-model="filterPayload.bankAccounts['Corporate lending']"
         class="col-span-full"
         name="Corporate Lending"
       >

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -132,11 +132,25 @@
         Business current accounts
       </CheckboxSection>
       <CheckboxSection
+        v-model="filterPayload.bankAccounts['Business Savings Accounts']"
+        class="col-span-full"
+        name="Business Savings Accounts"
+      >
+        Business savings accounts
+      </CheckboxSection>
+      <CheckboxSection
         v-model="filterPayload.bankAccounts['Small business lending']"
         class="col-span-full"
         name="Small business lending"
       >
         Small business lending
+      </CheckboxSection>
+      <CheckboxSection
+        v-model="filterPayload.bankAccounts['Small business lending']"
+        class="col-span-full"
+        name="Corporate Lending"
+      >
+        Corporate Lending
       </CheckboxSection>
       <CheckboxSection
         v-model="filterPayload.bankAccounts['Credit cards']"
@@ -209,7 +223,9 @@ const getDefaultFilter = () => ({
     saving: false,
     'Interest rates': false,
     'Business current accounts': false,
+    'Business savings accounts': false,
     'Small business lending': false,
+    'Corporate lending': false,
     'Credit cards': false,
     'Mortgage or loans': false
   },

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -125,9 +125,9 @@
         Interest rates
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Business current accounts']"
+        v-model="filterPayload.bankAccounts['Business accounts']"
         class="col-span-full"
-        name="Business current accounts"
+        name="Business accounts"
       >
         Business current accounts
       </CheckboxSection>
@@ -222,7 +222,7 @@ const getDefaultFilter = () => ({
     checking: false,
     saving: false,
     'Interest rates': false,
-    'Business current accounts': false,
+    'Business accounts': false,
     'Business savings accounts': false,
     'Small business lending': false,
     'Corporate lending': false,

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -125,11 +125,11 @@
         Interest rates
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Business accounts']"
+        v-model="filterPayload.bankAccounts['Business current accounts']"
         class="col-span-full"
-        name="Business accounts"
+        name="Business current accounts"
       >
-        Business accounts
+        Business current accounts
       </CheckboxSection>
       <CheckboxSection
         v-model="filterPayload.bankAccounts['Small business lending']"
@@ -208,7 +208,7 @@ const getDefaultFilter = () => ({
     checking: false,
     saving: false,
     'Interest rates': false,
-    'Business accounts': false,
+    'Business current accounts': false,
     'Small business lending': false,
     'Credit cards': false,
     'Mortgage or loans': false

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -14,7 +14,7 @@ export default function getFeatures (bankFeatures) {
     checking: isBE() ? 'Current Accounts' : 'Checking Accounts',
     saving: 'Savings Accounts',
     'Interest rates': 'Interest Rates',
-    'Business Current Accounts': 'Business Current Accounts',
+    'Business accounts': 'Business Current Accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgage or loans': 'Mortgage or Loan Options',

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -14,7 +14,7 @@ export default function getFeatures (bankFeatures) {
     checking: isBE() ? 'Current Accounts' : 'Checking Accounts',
     saving: 'Savings Accounts',
     'Interest rates': 'Interest Rates',
-    'Business accounts': 'Business Accounts',
+    'Business current accounts': 'Business current accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgage or loans': 'Mortgage or Loan Options',

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -18,7 +18,9 @@ export default function getFeatures (bankFeatures) {
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgage or loans': 'Mortgage or Loan Options',
-    'Deposit protection': 'Deposit Protection'
+    'Deposit protection': 'Deposit Protection',
+    'Corporate Lending': 'Corporate Lending',
+    'Business Savings Accounts': 'Business Savings Accounts'
   }
 
   // initialize result object with all false

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -14,7 +14,7 @@ export default function getFeatures (bankFeatures) {
     checking: isBE() ? 'Current Accounts' : 'Checking Accounts',
     saving: 'Savings Accounts',
     'Interest rates': 'Interest Rates',
-    'Business current accounts': 'Business current accounts',
+    'Business Current Accounts': 'Business Current Accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgage or loans': 'Mortgage or Loan Options',


### PR DESCRIPTION
Introduce new fields: `Corporate Lending`, `Business Savings Accounts`

Rename field: `Business accounts` -> `Business current accounts`


Weirdly, I wasn't able to rename the data.bank.green feature type to `Business current accounts` and recconfigure it here. Doing so broke filtering. I'm interested in ideas or direct commits to do that. I used [Triodos UK](https://data.bank.green/admin/brand/brand/166/) as a test case, which still has an (unused) feature, `Business current accounts`.
