### PR TITLE
League table hot update

### DIFF
--- a/components/blog/BlogLeagueTable.vue
+++ b/components/blog/BlogLeagueTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="block w-full overflow-x-auto mb-8">
+  <div class="block w-full sm:w-4/5 overflow-x-auto mb-8">
     <table class="items-center bg-transparent w-full border-collapse bg-white">
       <thead>
         <tr class="bg-sushi-200 text-primary-dark">
@@ -51,6 +51,6 @@ const { data } = useAsyncData<IGoogleSheetResponse>(() => $fetch('/api/league-ta
 const tableRows = computed<ITableRow[]>(() => data.value?.values.map(sheetRow => ({
   imageURL: sheetRow[0] || null,
   institution: sheetRow[1],
-  rating: sheetRow[4]
+  rating: sheetRow[3]
 }) || []))
 </script>

--- a/components/blog/BlogLeagueTable.vue
+++ b/components/blog/BlogLeagueTable.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="block w-full overflow-x-auto mb-8">
+    <table class="items-center bg-transparent w-full border-collapse bg-white">
+      <thead>
+        <tr class="bg-sushi-200 text-primary-dark">
+          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
+            No
+          </th>
+          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
+            Institution Name
+          </th>
+          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
+            Score
+          </th>
+          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
+            Rating
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr
+          v-for="(row, index) in tableRows"
+          :key="index"
+          :class="(index %2) ? 'bg-sushi-50' : 'bg-white'"
+        >
+          <th class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 text-left font-normal">
+            {{ index + 1 }}
+          </th>
+          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 font-semibold">
+            {{ row.institution }}
+          </td>
+          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 ">
+            {{ row.score }}
+          </td>
+          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4">
+            {{ row.rating }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+<script setup lang="ts">
+interface IGoogleSheetResponse {
+    range: string;
+    majorDimension: string;
+    values: string[][]
+}
+interface ITableRow {
+    institution: string;
+    score: number;
+    rating: string;
+}
+const { data } = useAsyncData<IGoogleSheetResponse>(() => $fetch('/api/league-table'))
+// const tableColumns = [
+//   { field: 'institution', label: 'Institution Name' },
+//   { field: 'score', label: 'Score' },
+//   { field: 'rating', label: 'Rating' }
+// ]
+const tableRows = computed<ITableRow[]>(() => data.value?.values.map(sheetRow => ({
+  institution: sheetRow[0],
+  score: Number.parseInt(sheetRow[1]),
+  rating: sheetRow[2]
+}) || []))
+</script>

--- a/components/blog/BlogLeagueTable.vue
+++ b/components/blog/BlogLeagueTable.vue
@@ -18,8 +18,10 @@
           :key="index"
           :class="(index %2) ? 'bg-sushi-50' : 'bg-white'"
         >
-          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 font-semibold">
-            {{ row.institution }}
+          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 font-semibold flex gap-2 items-center">
+            <img v-if="row.imageURL" class="w-10 h-10" :src="row.imageURL" alt="">
+            <div v-else class="w-10" />
+            <span>{{ row.institution }}</span>
           </td>
           <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4">
             {{ row.rating }}
@@ -36,6 +38,7 @@ interface IGoogleSheetResponse {
     values: string[][]
 }
 interface ITableRow {
+    imageURL: string | null;
     institution: string;
     rating: string;
 }
@@ -46,6 +49,7 @@ const { data } = useAsyncData<IGoogleSheetResponse>(() => $fetch('/api/league-ta
 //   { field: 'rating', label: 'Rating' }
 // ]
 const tableRows = computed<ITableRow[]>(() => data.value?.values.map(sheetRow => ({
+  imageURL: sheetRow[0] || null,
   institution: sheetRow[1],
   rating: sheetRow[4]
 }) || []))

--- a/components/blog/BlogLeagueTable.vue
+++ b/components/blog/BlogLeagueTable.vue
@@ -4,13 +4,7 @@
       <thead>
         <tr class="bg-sushi-200 text-primary-dark">
           <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
-            No
-          </th>
-          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
             Institution Name
-          </th>
-          <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
-            Score
           </th>
           <th class="px-6  align-middle border border-solid  py-3 text-sm uppercase border-l-0 border-r-0 whitespace-nowrap font-semibold text-left">
             Rating
@@ -24,14 +18,8 @@
           :key="index"
           :class="(index %2) ? 'bg-sushi-50' : 'bg-white'"
         >
-          <th class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 text-left font-normal">
-            {{ index + 1 }}
-          </th>
           <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 font-semibold">
             {{ row.institution }}
-          </td>
-          <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4 ">
-            {{ row.score }}
           </td>
           <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-sm whitespace-nowrap p-4">
             {{ row.rating }}
@@ -49,7 +37,6 @@ interface IGoogleSheetResponse {
 }
 interface ITableRow {
     institution: string;
-    score: number;
     rating: string;
 }
 const { data } = useAsyncData<IGoogleSheetResponse>(() => $fetch('/api/league-table'))
@@ -59,8 +46,7 @@ const { data } = useAsyncData<IGoogleSheetResponse>(() => $fetch('/api/league-ta
 //   { field: 'rating', label: 'Rating' }
 // ]
 const tableRows = computed<ITableRow[]>(() => data.value?.values.map(sheetRow => ({
-  institution: sheetRow[0],
-  score: Number.parseInt(sheetRow[1]),
-  rating: sheetRow[2]
+  institution: sheetRow[1],
+  rating: sheetRow[4]
 }) || []))
 </script>

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -17,7 +17,6 @@
           </span>
         </div>
         <div class="flex flex-col justify-center items-center">
-          <BlogLeagueTable v-if="displayLeagueTable" />
           <div
             style="width: 100%"
             class="prose sm:prose-lg xl:prose-xl break-words"
@@ -28,6 +27,7 @@
               :context="{ takeaction: true }"
             />
           </div>
+          <BlogLeagueTable v-if="displayLeagueTable" />
         </div>
       </div>
     </div>
@@ -141,8 +141,7 @@ const url = computed(() => {
 })
 
 // TODO: move to Prismic
-// const displayLeagueTable = computed(() => slug === 'eight-simple-steps-to-switching-your-bank')
-const displayLeagueTable = computed(() => true)
+const displayLeagueTable = computed(() => slug === 'uk-banks-league-table')
 
 useHead({
   title,

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -141,7 +141,8 @@ const url = computed(() => {
 })
 
 // TODO: move to Prismic
-const displayLeagueTable = computed(() => slug === 'eight-simple-steps-to-switching-your-bank')
+// const displayLeagueTable = computed(() => slug === 'eight-simple-steps-to-switching-your-bank')
+const displayLeagueTable = computed(() => true)
 
 useHead({
   title,

--- a/pages/blog/[slug].vue
+++ b/pages/blog/[slug].vue
@@ -17,6 +17,7 @@
           </span>
         </div>
         <div class="flex flex-col justify-center items-center">
+          <BlogLeagueTable v-if="displayLeagueTable" />
           <div
             style="width: 100%"
             class="prose sm:prose-lg xl:prose-xl break-words"
@@ -138,6 +139,9 @@ const description = getDescription(post)
 const url = computed(() => {
   return `https://bank.green/blog/${slug}`
 })
+
+// TODO: move to Prismic
+const displayLeagueTable = computed(() => slug === 'eight-simple-steps-to-switching-your-bank')
 
 useHead({
   title,

--- a/server/api/league-table.get.ts
+++ b/server/api/league-table.get.ts
@@ -1,0 +1,8 @@
+const SPREADSHEET_ID = '1kUhXAJuCglttg6bUYQvcGilyXnUKAtW99Z8bJzQi0LU'
+const GOOGLE_API_KEY = 'AIzaSyBT2wft2I8F5Pp9qH_I22bTaeAU60IsKSI'
+
+export default defineEventHandler(async () => {
+  const rowRange = 'Lowest Score!A2:E'
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SPREADSHEET_ID}/values/${rowRange}?key=${GOOGLE_API_KEY}`
+  return await $fetch(url)
+})


### PR DESCRIPTION
Base on request from Zak
> So we are trying to create a "League Table" of the 103 banks we have rated in the UK, but Prismic seems to require a bit of programming work in order to allow tables. [Here is the page](https://community.prismic.io/t/how-to-create-a-table/5460) that describes how to create a table in Prismic. Ideally, we would also include the logos of the banks in the table, which I have gathered into a folder.
I am also attaching a basic mockup here of how the table should ideally look. Please note:
a) It should be part of a blog post vs. a separate page.
b) I could not draw this, but the table column headings ideally should have the same colour as the "Donate" button in the top right, i.e. White text on green background.
c) Please ignore the blue background behind the table. I just wished to show how this table could look like on the blog page.

Main idea:
- Create an server api endpoint `/api/league-table` to directly get data from Google Sheet
- Display the API data into blog page

What's next:
- Add image URL column to the Google Sheet and add avaiable image URL for each bank
- Display bank image
- Add pagination and other features to the table
- Control table display and content via Prismic