### PR TITLE
Albert/groot 250 bug users cannot filter by mortgages or loans

### DIFF
--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -160,9 +160,9 @@
         Credit cards
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Mortgage or loans']"
+        v-model="filterPayload.bankAccounts['Mortgages or loans']"
         class="col-span-full"
-        name="Mortgage or loans"
+        name="Mortgages or Loans"
       >
         Mortgage or loan options
       </CheckboxSection>
@@ -227,7 +227,7 @@ const getDefaultFilter = () => ({
     'Small business lending': false,
     'Corporate lending': false,
     'Credit cards': false,
-    'Mortgage or loans': false
+    'Mortgages or Loans': false
   },
   security: {
     'Deposit protection': false

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -160,7 +160,7 @@
         Credit cards
       </CheckboxSection>
       <CheckboxSection
-        v-model="filterPayload.bankAccounts['Mortgages or loans']"
+        v-model="filterPayload.bankAccounts['Mortgages or Loans']"
         class="col-span-full"
         name="Mortgages or Loans"
       >

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -17,7 +17,7 @@ export default function getFeatures (bankFeatures) {
     'Business accounts': 'Business Current Accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
-    'Mortgage or loans': 'Mortgage or Loan Options',
+    'Mortgages or Loans': 'Mortgage or Loan Options',
     'Deposit protection': 'Deposit Protection',
     'Corporate Lending': 'Corporate Lending',
     'Business Savings Accounts': 'Business Savings Accounts'


### PR DESCRIPTION
https://linear.app/bankgreen/issue/GROOT-250/bug-users-cannot-filter-by-mortgages-or-loans

Implementation details:

1. Added filter for Mortgage or loans option - Thank you @RogerTangos for adding this.
2. Just updated camel case for loans in Mortgage or Loans options

