### PR TITLE
Add title field for home page in prismic and keep fallback text

### DIFF
--- a/customtypes/homepage/index.json
+++ b/customtypes/homepage/index.json
@@ -3,8 +3,13 @@
   "label": "HomePage",
   "repeatable": false,
   "status": true,
+  "format": "custom",
   "json": {
     "Main": {
+      "title": {
+        "type": "Text",
+        "config": { "label": "Title", "placeholder": "" }
+      },
       "description1": {
         "type": "StructuredText",
         "config": {
@@ -59,6 +64,5 @@
         }
       }
     }
-  },
-  "format": "custom"
+  }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@
           <h1
             class="text-center text-2xl font-semibold text-gray-800 sm:text-5xl"
           >
-            Is your money being used to fund climate chaos?
+            {{ home?.data.title || "Is your money being used to fund climate chaos?" }}
           </h1>
           <div
             class="flex flex-col md:flex-row items-stretch md:items-center space-y-2 md:space-y-0 md:space-x-4 mt-8 md:mt-10 md:mb-10"

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -1646,6 +1646,17 @@ type HomepageDocumentDataSlices1Slice = FeaturedInSliceSlice;
  */
 interface HomepageDocumentData {
   /**
+   * Title field in *HomePage*
+   *
+   * - **Field Type**: Text
+   * - **Placeholder**: *None*
+   * - **API ID Path**: homepage.title
+   * - **Tab**: Main
+   * - **Documentation**: https://prismic.io/docs/field#key-text
+   */
+  title: prismic.KeyTextField;
+
+  /**
    * Description1 field in *HomePage*
    *
    * - **Field Type**: Rich Text


### PR DESCRIPTION
Hi! 

I've added the title field for the home page in Prismic. I checked that for some pages the title field type is "Rich Text" while in others is just plain "Key Text". I created it as "Key Text" but let me know if it needs to be of type "Rich Text" instead. 
Also, I've kept the previous text as a fallback. 

Thanks!