### PR TITLE
Add rings using svg + background-image

### DIFF
--- a/public/img/backgrounds/circle-quarter.svg
+++ b/public/img/backgrounds/circle-quarter.svg
@@ -1,0 +1,13 @@
+<svg width="1200" height="740" viewBox="0 0 1200 740" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_7922_6557)">
+        <ellipse opacity="0.2" cx="845.061" cy="366.569" rx="845.061" ry="366.569"
+            transform="matrix(-0.866025 -0.5 -0.549142 0.835729 1221.67 1045.53)" fill="#56668F" />
+        <ellipse opacity="0.2" cx="845.061" cy="366.569" rx="845.061" ry="366.569"
+            transform="matrix(-0.866025 -0.5 -0.549142 0.835729 1211.61 1124.82)" fill="#56668F" />
+    </g>
+    <defs>
+        <clipPath id="clip0_7922_6557">
+            <rect width="1200" height="740" fill="white" />
+        </clipPath>
+    </defs>
+</svg>

--- a/slices/LeadGen/index.vue
+++ b/slices/LeadGen/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div
     id="lead-gen"
-    style="scroll-margin-top: 80px"
-    class="flex flex-col lg:flex-row gap-12 lg:gap-20 rounded-xl py-6 md:py-12 px-6 md:px-16 bg-primary-dark"
+    style="scroll-margin-top: 80px; background-image: url('/img/backgrounds/circle-quarter.svg'); background-position: left bottom;"
+    class="flex flex-col lg:flex-row gap-12 lg:gap-20 rounded-xl py-6 md:py-12 px-6 md:px-16 bg-primary-dark bg-no-repeat"
   >
     <div class="flex flex-col gap-12">
       <h2


### PR DESCRIPTION
- Create new folder in public/img to store svg backgrounds
- Use background-image over inline svg because no need to add unnecessary markup and styles (we would need to make the parent relative, the svg absolute, add z-index, etc.)
- Use background-image with url over custom radial-gradient because it's more accurate to the design and more responsive