### PR TITLE
Use "Checking" instead of "Current" for US banks

### DIFF
--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -20,10 +20,6 @@
             {{ institutionType || "Bank" }}
           </p>
           <p>
-            <strong>Countries:</strong>
-            {{ $props.countries.map(x => x.code).join(", ") }}
-          </p>
-          <p>
             <strong>Mobile Banking:</strong>
             {{ getBankFeature("Mobile banking") }}
           </p>

--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -52,7 +52,7 @@
       <template #products>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:-mr-24">
           <p>
-            <strong>{{ isBE() ? 'Checking' : 'Current' }} Accounts:</strong>
+            <strong>{{ isBE() ? 'Current' : 'Checking' }} Accounts:</strong>
             {{ getBankFeature("checking") }}
           </p>
           <p>

--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -250,7 +250,6 @@ const props = defineProps<{
   website: string;
   rating: string;
   bankFeatures: BankFeature[];
-  countries: { code: string; }[];
   tag: string;
   prismicPageData: Record<string, any> | null;
   prismicDefaultPageData: Record<string, any> | null;

--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -20,6 +20,10 @@
             {{ institutionType || "Bank" }}
           </p>
           <p>
+            <strong>Countries:</strong>
+            {{ $props.countries.map(x => x.code).join(", ") }}
+          </p>
+          <p>
             <strong>Mobile Banking:</strong>
             {{ getBankFeature("Mobile banking") }}
           </p>
@@ -52,7 +56,7 @@
       <template #products>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:-mr-24">
           <p>
-            <strong>Current Accounts:</strong>
+            <strong>{{ props.countries.find(x => x.code == 'US') ? 'Checking' : 'Current' }} Accounts:</strong>
             {{ getBankFeature("checking") }}
           </p>
           <p>
@@ -248,6 +252,7 @@ const props = defineProps<{
   website: string;
   rating: string;
   bankFeatures: BankFeature[];
+  countries: { code: string; }[];
   tag: string;
   prismicPageData: Record<string, any> | null;
   prismicDefaultPageData: Record<string, any> | null;

--- a/components/eco-bank/EcoBankDetail.vue
+++ b/components/eco-bank/EcoBankDetail.vue
@@ -52,7 +52,7 @@
       <template #products>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:-mr-24">
           <p>
-            <strong>{{ props.countries.find(x => x.code == 'US') ? 'Checking' : 'Current' }} Accounts:</strong>
+            <strong>{{ isBE() ? 'Checking' : 'Current' }} Accounts:</strong>
             {{ getBankFeature("checking") }}
           </p>
           <p>
@@ -231,7 +231,9 @@
 </template>
 
 <script setup lang="ts">
+
 import { SliceZoneComponents, SliceLike } from '@prismicio/vue'
+const { isBE } = useCountry()
 
 interface BankFeature {
   offered: string;

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -129,7 +129,7 @@
         class="col-span-full"
         name="Business accounts"
       >
-        Business current accounts
+        {{ isBE() ? "Business current accounts" : "Business checking accounts" }}
       </CheckboxSection>
       <CheckboxSection
         v-model="filterPayload.bankAccounts['Business savings accounts']"

--- a/pages/sustainable-eco-banks/[bankTag].vue
+++ b/pages/sustainable-eco-banks/[bankTag].vue
@@ -25,7 +25,6 @@
       :website="details.website"
       :rating="details.rating"
       :bank-features="details.bankFeatures"
-      :countries="details.countries"
       :tag="details.tag"
       :prismic-page-data="prismicPageData"
       :prismic-default-page-data="prismicDefaultPageData"

--- a/pages/sustainable-eco-banks/[bankTag].vue
+++ b/pages/sustainable-eco-banks/[bankTag].vue
@@ -25,6 +25,7 @@
       :website="details.website"
       :rating="details.rating"
       :bank-features="details.bankFeatures"
+      :countries="details.countries"
       :tag="details.tag"
       :prismic-page-data="prismicPageData"
       :prismic-default-page-data="prismicDefaultPageData"
@@ -51,7 +52,6 @@ if (!bankTag) {
   const { client } = usePrismic()
 
   details.value = await getBankDetail(bankTag)
-
   const prismicResponse = await useAsyncData('sfipage', () =>
     client.getByUID('sfipage', bankTag)
   )

--- a/pages/sustainable-eco-banks/[bankTag].vue
+++ b/pages/sustainable-eco-banks/[bankTag].vue
@@ -52,6 +52,7 @@ if (!bankTag) {
   const { client } = usePrismic()
 
   details.value = await getBankDetail(bankTag)
+  
   const prismicResponse = await useAsyncData('sfipage', () =>
     client.getByUID('sfipage', bankTag)
   )

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -5,16 +5,17 @@ export default function getFeatures (bankFeatures) {
     return {}
   }
 
+  const checkingName = isBE() ? 'Current' : 'Checking'
   // features in this dict will show an x if they are not available for a bank
   const featureDict = {
     'Mobile banking': 'Mobile Banking',
     'Free ATM network': 'Free ATM Network',
     'No overdraft fee': 'No Overdraft Fee',
     'No account maintenance fee': 'No Account Maintenance Fees',
-    checking: isBE() ? 'Current Accounts' : 'Checking Accounts',
+    checking: checkingName + ' Accounts',
     saving: 'Savings Accounts',
     'Interest rates': 'Interest Rates',
-    'Business accounts': 'Business Current Accounts',
+    'Business accounts': 'Business ' + checkingName + ' Accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgages or Loans': 'Mortgage or Loan Options',


### PR DESCRIPTION
I noticed the bank info page used the term "Current Accounts" which I hadn't ever heard of but learned is common in the UK.  Added logic to use "checking account" for US banks