### PR TITLE
Sustainable Bank List UI Improvements

### DIFF
--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -117,7 +117,7 @@ const bankInfo = computed(() => {
 
   for (const [featKey, featValue] of Object.entries(allFeatures)) {
     // Check if the feature is an account and process it
-    const accountKeys = ['accounts', 'credit card']
+    const accountKeys = ['accounts', 'credit card', 'mortgage', 'lending']
     if (!featValue?.hide || featValue?.checked) {
       if (accountKeys.find(x => featKey?.toLowerCase().includes(x))) {
         accounts.push(featKey.replace('Accounts', '').trim())

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -1,138 +1,104 @@
 <template>
-  
   <NuxtLink
     :to="item ? `/sustainable-eco-banks/${item.tag}` : ''"
     class="block mb-6 rounded-2xl shadow-sm bg-white transition duration-150 ease-in-out hover:bg-gray-50 border border-transparent hover:border-sushi-500"
   >
-  <div class="ribbonContainer">
-    <div
-      class="py-3 pl-4 pr-5 border-b border-gray-200 flex items-center justify-between"
-    >
-    <p v-if="item.topPick" class="ribbon text-xs">Top Pick</p>
+    <div class="ribbonContainer">
+      <div
+        class="py-3 pl-4 pr-5 border-b border-gray-200 flex items-center justify-between"
+      >
+        <p v-if="item.topPick" class="ribbon text-xs">
+          Top Pick
+        </p>
+
+        <transition
+          enter-active-class="duration-200 transform-gpu origin-top ease-out"
+          enter-from-class="opacity-0 scale-y-95"
+          enter-to-class="opacity-100 scale-y-100"
+          leave-active-class="duration-100 transform-gpu origin-top ease-in"
+          leave-from-class="opacity-100 scale-y-100"
+          leave-to-class="opacity-0 scale-y-95"
+          mode="out-in"
+        >
+          <div v-if="item" class="flex items-center truncate">
+            <div class="relative w-12 h-12">
+              <ClearbitLogo
+                :url="item.website"
+                :size="48"
+                img-class="absolute inset-0 z-20"
+              />
+            </div>
+            <div
+              class="ml-3 flex-1 flex items-center font-semibold text-gray-800 truncate"
+            >
+              <span>
+                {{ item.name }}
+              </span>
+              <img
+                v-if="item.fossilFreeAlliance"
+                class="w-10 ml-4"
+                src="/img/certification/fossil-free-certified.png"
+                alt="Fossil Free Certification"
+              >
+              <div class="ml-4 text-xs text-gray-500">
+                {{ item.interest_rates }}
+              </div>
+            </div>
+          </div>
+
+          <div v-else class="w-full flex items-center truncate">
+            <div class="w-12 h-12 bg-gray-100 rounded-xl animate-pulse" />
+            <div class="ml-3 flex-1 font-semibold text-gray-200 block truncate">
+              loading...
+            </div>
+          </div>
+        </transition>
+
+        <svg
+          class="text-sushi-500"
+          width="7"
+          height="13"
+          viewBox="0 0 7 13"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M1 11.5L6 6.5L1 1.5"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </div>
 
       <transition
         enter-active-class="duration-200 transform-gpu origin-top ease-out"
-        enter-from-class="opacity-0 scale-y-95"
-        enter-to-class="opacity-100 scale-y-100"
+        enter-from-class="opacity-0 scale-95"
+        enter-to-class="opacity-100 scale-100"
         leave-active-class="duration-100 transform-gpu origin-top ease-in"
-        leave-from-class="opacity-100 scale-y-100"
-        leave-to-class="opacity-0 scale-y-95"
-        mode="out-in"
+        leave-from-class="opacity-100 scale-100"
+        leave-to-class="opacity-0 scale-95"
       >
-        <div v-if="item" class="flex items-center truncate">
-          
-          <div class="relative w-12 h-12">
-            <ClearbitLogo
-              :url="item.website"
-              :size="48"
-              img-class="absolute inset-0 z-20"
-            />
-          </div>
+        <div>
           <div
-            class="ml-3 flex-1 flex items-center font-semibold text-gray-800 truncate"
+            class="flex flex-col md:flex-row text-xs ml-12 mt-4 justify-between"
           >
-            <span>
-              {{ item.name }}
-            </span>
-            <img
-              v-if="item.fossilFreeAlliance"
-              class="w-10 ml-4"
-              src="/img/certification/fossil-free-certified.png"
-              alt="Fossil Free Certification"
-            >
-            <div class="ml-4 text-xs text-gray-500">
-            {{ item.interest_rates }}
-            </div>
+            <span>{{ accounts.join(" | ") }}</span>
+            <span class="mr-6 mt-2 md:mt-0">Rating: {{ item.rating }}</span>
           </div>
-        </div>
 
-        <div v-else class="w-full flex items-center truncate">
-          <div class="w-12 h-12 bg-gray-100 rounded-xl animate-pulse" />
-          <div class="ml-3 flex-1 font-semibold text-gray-200 block truncate">
-            loading...
+          <div
+            v-if="Object.keys(features).length"
+            class="py-4 px-7 flex flex-wrap"
+          >
+            <EcoBankFeaturesList :features="features" />
           </div>
         </div>
       </transition>
-
-      <svg
-        class="text-sushi-500"
-        width="7"
-        height="13"
-        viewBox="0 0 7 13"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M1 11.5L6 6.5L1 1.5"
-          stroke="currentColor"
-          stroke-width="1.8"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-    </div>
-
-    <transition
-      enter-active-class="duration-200 transform-gpu origin-top ease-out"
-      enter-from-class="opacity-0 scale-95"
-      enter-to-class="opacity-100 scale-100"
-      leave-active-class="duration-100 transform-gpu origin-top ease-in"
-      leave-from-class="opacity-100 scale-100"
-      leave-to-class="opacity-0 scale-95"
-    >
-      <div>
-        <div class="flex flex-col md:flex-row text-xs ml-12 mt-4 justify-between">
-            <span>{{ accounts.join(' | ') }}</span>
-            <span class="mr-6 mt-2 md:mt-0">Rating: {{ item.rating }}</span>
-        </div>
-
-      <div v-if="Object.keys(features).length" class="py-4 px-7 flex flex-wrap">
-        <EcoBankFeaturesList :features="features" />
-      </div>
-    </div>
-    </transition>
     </div>
   </NuxtLink>
 </template>
-
-<style>
-.ribbonContainer {
-		overflow: hidden; /* required */
-		position: relative; /* required for demo */
-	}
-
-	.ribbon {
-		margin: 0;
-		background: #FC7753;
-		color: rgb(72, 72, 72);
-		padding: 0.3em 0;
-		position: absolute;
-		bottom: 0;
-		right: 0;
-		transform: translateX(35%) translateY(5%) rotate(-45deg);
-		transform-origin: bottom left;
-		font-size: small;
-	}
-
-	.ribbon:before,
-	.ribbon:after {
-		content: '';
-		position: absolute;
-		top: 0;
-		margin: 0 -1px; /* tweak */
-		width: 100%;
-		height: 100%;
-		background: #FC7753;
-	}
-
-	.ribbon:before {
-		right: 100%;
-	}
-
-	.ribbon:after {
-		left: 100%;
-	}
-  </style>
 
 <script setup lang="ts">
 import ClearbitLogo from '@/components/icons/ClearbitLogo.vue'
@@ -143,7 +109,10 @@ const props = defineProps<{
 
 const features = computed(() => {
   // filter our credit card
-  const features = getFeatures(props.item?.other_features, true) as Record<string, any>
+  const features = getFeatures(props.item?.other_features, true) as Record<
+    string,
+    any
+  >
   const allFeatures: Record<string, any> = {}
   for (const [featKey, featValue] of Object.entries(features)) {
     if (!featValue?.hide || featValue?.checked) {
@@ -154,14 +123,55 @@ const features = computed(() => {
 })
 
 const accounts = computed(() => {
-  let relevantAccounts = [];
-  const features = getFeatures(props.item?.other_features) as Record<string, any>
+  const relevantAccounts = []
+  const features = getFeatures(props.item?.other_features) as Record<
+    string,
+    any
+  >
   for (const [featKey, featValue] of Object.entries(features)) {
     if (featKey?.toLowerCase().includes('accounts')) {
-      relevantAccounts.push(featKey.replace('Accounts', '').trim());
+      relevantAccounts.push(featKey.replace('Accounts', '').trim())
     }
   }
-  return relevantAccounts;
-});
-
+  return relevantAccounts
+})
 </script>
+
+<style>
+.ribbonContainer {
+  overflow: hidden; /* required */
+  position: relative; /* required for demo */
+}
+
+.ribbon {
+  margin: 0;
+  background: #fc7753;
+  color: rgb(72, 72, 72);
+  padding: 0.3em 0;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  transform: translateX(35%) translateY(5%) rotate(-45deg);
+  transform-origin: bottom left;
+  font-size: small;
+}
+
+.ribbon:before,
+.ribbon:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  margin: 0 -1px; /* tweak */
+  width: 100%;
+  height: 100%;
+  background: #fc7753;
+}
+
+.ribbon:before {
+  right: 100%;
+}
+
+.ribbon:after {
+  left: 100%;
+}
+</style>

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -1,11 +1,15 @@
 <template>
+  
   <NuxtLink
     :to="item ? `/sustainable-eco-banks/${item.tag}` : ''"
     class="block mb-6 rounded-2xl shadow-sm bg-white transition duration-150 ease-in-out hover:bg-gray-50 border border-transparent hover:border-sushi-500"
   >
+  <div class="ribbonContainer">
     <div
       class="py-3 pl-4 pr-5 border-b border-gray-200 flex items-center justify-between"
     >
+    <p v-if="item.topPick" class="ribbon text-xs">Top Pick</p>
+
       <transition
         enter-active-class="duration-200 transform-gpu origin-top ease-out"
         enter-from-class="opacity-0 scale-y-95"
@@ -16,6 +20,7 @@
         mode="out-in"
       >
         <div v-if="item" class="flex items-center truncate">
+          
           <div class="relative w-12 h-12">
             <ClearbitLogo
               :url="item.website"
@@ -34,12 +39,6 @@
               class="w-10 ml-4"
               src="/img/certification/fossil-free-certified.png"
               alt="Fossil Free Certification"
-            >
-            <img
-              v-if="item.topPick"
-              class="w-10 ml-4"
-              src="/img/certification/TopPick.svg"
-              alt="Top Pick"
             >
             <div class="ml-4 text-xs text-gray-500">
             {{ item.interest_rates }}
@@ -81,35 +80,88 @@
       leave-from-class="opacity-100 scale-100"
       leave-to-class="opacity-0 scale-95"
     >
-      
+      <div>
+        <div class="flex flex-col md:flex-row text-xs ml-12 mt-4 justify-between">
+            <span>{{ accounts.join(' | ') }}</span>
+            <span class="mr-6 mt-2 md:mt-0">Rating: {{ item.rating }}</span>
+        </div>
+
       <div v-if="Object.keys(features).length" class="py-4 px-7 flex flex-wrap">
         <EcoBankFeaturesList :features="features" />
       </div>
+    </div>
     </transition>
+    </div>
   </NuxtLink>
 </template>
+
+<style>
+.ribbonContainer {
+		overflow: hidden; /* required */
+		position: relative; /* required for demo */
+	}
+
+	.ribbon {
+		margin: 0;
+		background: #FC7753;
+		color: rgb(72, 72, 72);
+		padding: 0.3em 0;
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		transform: translateX(35%) translateY(5%) rotate(-45deg);
+		transform-origin: bottom left;
+		font-size: small;
+	}
+
+	.ribbon:before,
+	.ribbon:after {
+		content: '';
+		position: absolute;
+		top: 0;
+		margin: 0 -1px; /* tweak */
+		width: 100%;
+		height: 100%;
+		background: #FC7753;
+	}
+
+	.ribbon:before {
+		right: 100%;
+	}
+
+	.ribbon:after {
+		left: 100%;
+	}
+  </style>
 
 <script setup lang="ts">
 import ClearbitLogo from '@/components/icons/ClearbitLogo.vue'
 
 const props = defineProps<{
   item: any;
-  isNoCredit: Boolean;
 }>()
 
 const features = computed(() => {
   // filter our credit card
-  const features = getFeatures(props.item?.other_features) as Record<string, any>
+  const features = getFeatures(props.item?.other_features, true) as Record<string, any>
   const allFeatures: Record<string, any> = {}
   for (const [featKey, featValue] of Object.entries(features)) {
-    if (
-      (props.isNoCredit && featKey === 'Credit Card') ||
-      !featValue.isChecked
-    ) {
-      continue
+    if (!featValue?.hide || featValue?.checked) {
+      allFeatures[featKey] = features[featValue] ?? features[featKey]
     }
-    allFeatures[featKey] = features[featKey]
   }
   return allFeatures
 })
+
+const accounts = computed(() => {
+  let relevantAccounts = [];
+  const features = getFeatures(props.item?.other_features) as Record<string, any>
+  for (const [featKey, featValue] of Object.entries(features)) {
+    if (featKey?.toLowerCase().includes('accounts')) {
+      relevantAccounts.push(featKey.replace('Accounts', '').trim());
+    }
+  }
+  return relevantAccounts;
+});
+
 </script>

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -108,20 +108,21 @@ const props = defineProps<{
 }>()
 
 const bankInfo = computed(() => {
-  const features = getFeatures(props.item?.bankFeatures, true) as Record<
+  const allFeatures = getFeatures(props.item?.bankFeatures, true) as Record<
     string,
     any
   >
-  const allFeatures: Record<string, any> = {}
+  const features: Record<string, any> = {}
   const accounts: string[] = []
 
-  for (const [featKey, featValue] of Object.entries(features)) {
+  for (const [featKey, featValue] of Object.entries(allFeatures)) {
     // Check if the feature is an account and process it
-    if (featKey?.toLowerCase().includes('accounts')) {
+    const accountKeys = ['accounts', 'credit card']
+    if (accountKeys.find(x => featKey?.toLowerCase().includes(x))) {
       accounts.push(featKey.replace('Accounts', '').trim())
     } else if (!featValue?.hide || featValue?.checked) {
       // Only add feature if it's not hidden or if it's checked
-      allFeatures[featKey] = featValue ?? features[featKey]
+      features[featKey] = featValue ?? allFeatures[featKey]
     }
   }
 

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -118,11 +118,13 @@ const bankInfo = computed(() => {
   for (const [featKey, featValue] of Object.entries(allFeatures)) {
     // Check if the feature is an account and process it
     const accountKeys = ['accounts', 'credit card']
-    if (accountKeys.find(x => featKey?.toLowerCase().includes(x))) {
-      accounts.push(featKey.replace('Accounts', '').trim())
-    } else if (!featValue?.hide || featValue?.checked) {
-      // Only add feature if it's not hidden or if it's checked
-      features[featKey] = featValue ?? allFeatures[featKey]
+    if (!featValue?.hide || featValue?.checked) {
+      if (accountKeys.find(x => featKey?.toLowerCase().includes(x))) {
+        accounts.push(featKey.replace('Accounts', '').trim())
+      } else {
+        // Only add feature if it's not hidden or if it's checked
+        features[featKey] = featValue ?? allFeatures[featKey]
+      }
     }
   }
 

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -80,7 +80,7 @@
         leave-from-class="opacity-100 scale-100"
         leave-to-class="opacity-0 scale-95"
       >
-        <div>
+        <div v-if="item">
           <div
             class="flex flex-col md:flex-row text-xs ml-12 mt-4 justify-between"
           >
@@ -128,7 +128,7 @@ const accounts = computed(() => {
     string,
     any
   >
-  for (const [featKey, featValue] of Object.entries(features)) {
+  for (const [featKey, _] of Object.entries(features)) {
     if (featKey?.toLowerCase().includes('accounts')) {
       relevantAccounts.push(featKey.replace('Accounts', '').trim())
     }

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -84,15 +84,15 @@
           <div
             class="flex flex-col md:flex-row text-xs ml-12 mt-4 justify-between"
           >
-            <span>{{ accounts.join(" | ") }}</span>
+            <span>{{ bankInfo.accounts.join(" | ") }}</span>
             <span class="mr-6 mt-2 md:mt-0">Rating: {{ item.rating }}</span>
           </div>
 
           <div
-            v-if="Object.keys(features).length"
+            v-if="Object.keys(bankInfo.features).length"
             class="py-4 px-7 flex flex-wrap"
           >
-            <EcoBankFeaturesList :features="features" />
+            <EcoBankFeaturesList :features="bankInfo.features" />
           </div>
         </div>
       </transition>
@@ -107,33 +107,25 @@ const props = defineProps<{
   item: any;
 }>()
 
-const features = computed(() => {
-  // filter our credit card
-  const features = getFeatures(props.item?.other_features, true) as Record<
+const bankInfo = computed(() => {
+  const features = getFeatures(props.item?.bankFeatures, true) as Record<
     string,
     any
   >
   const allFeatures: Record<string, any> = {}
-  for (const [featKey, featValue] of Object.entries(features)) {
-    if (!featValue?.hide || featValue?.checked) {
-      allFeatures[featKey] = features[featValue] ?? features[featKey]
-    }
-  }
-  return allFeatures
-})
+  const accounts: string[] = []
 
-const accounts = computed(() => {
-  const relevantAccounts = []
-  const features = getFeatures(props.item?.other_features) as Record<
-    string,
-    any
-  >
-  for (const [featKey, _] of Object.entries(features)) {
+  for (const [featKey, featValue] of Object.entries(features)) {
+    // Check if the feature is an account and process it
     if (featKey?.toLowerCase().includes('accounts')) {
-      relevantAccounts.push(featKey.replace('Accounts', '').trim())
+      accounts.push(featKey.replace('Accounts', '').trim())
+    } else if (!featValue?.hide || featValue?.checked) {
+      // Only add feature if it's not hidden or if it's checked
+      allFeatures[featKey] = featValue ?? features[featKey]
     }
   }
-  return relevantAccounts
+
+  return { features, accounts }
 })
 </script>
 

--- a/components/eco-bank/EcoBankCard.vue
+++ b/components/eco-bank/EcoBankCard.vue
@@ -41,6 +41,9 @@
               src="/img/certification/TopPick.svg"
               alt="Top Pick"
             >
+            <div class="ml-4 text-xs text-gray-500">
+            {{ item.interest_rates }}
+            </div>
           </div>
         </div>
 
@@ -78,6 +81,7 @@
       leave-from-class="opacity-100 scale-100"
       leave-to-class="opacity-0 scale-95"
     >
+      
       <div v-if="Object.keys(features).length" class="py-4 px-7 flex flex-wrap">
         <EcoBankFeaturesList :features="features" />
       </div>
@@ -95,7 +99,7 @@ const props = defineProps<{
 
 const features = computed(() => {
   // filter our credit card
-  const features = getFeatures(props.item?.bankFeatures) as Record<string, any>
+  const features = getFeatures(props.item?.other_features) as Record<string, any>
   const allFeatures: Record<string, any> = {}
   for (const [featKey, featValue] of Object.entries(features)) {
     if (

--- a/components/eco-bank/EcoBankCards.vue
+++ b/components/eco-bank/EcoBankCards.vue
@@ -8,13 +8,13 @@
     leave-to-class="opacity-0"
   >
     <li v-for="i in list.length" :key="i" class="list-none">
-      <EcoBankCard :item="list[i - 1]"/>
+      <EcoBankCard :item="list[i - 1]" />
     </li>
   </transition-group>
 </template>
 
 <script setup>
 defineProps({
-  list: Array,
+  list: Array
 })
 </script>

--- a/components/eco-bank/EcoBankCards.vue
+++ b/components/eco-bank/EcoBankCards.vue
@@ -8,7 +8,7 @@
     leave-to-class="opacity-0"
   >
     <li v-for="i in list.length" :key="i" class="list-none">
-      <EcoBankCard :item="list[i - 1]" :is-no-credit="isNoCredit" />
+      <EcoBankCard :item="list[i - 1]"/>
     </li>
   </transition-group>
 </template>
@@ -16,6 +16,5 @@
 <script setup>
 defineProps({
   list: Array,
-  isNoCredit: Boolean
 })
 </script>

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -129,7 +129,9 @@
         class="col-span-full"
         name="Business accounts"
       >
-        {{ isBE() ? "Business current accounts" : "Business checking accounts" }}
+        {{
+          isBE() ? "Business current accounts" : "Business checking accounts"
+        }}
       </CheckboxSection>
       <CheckboxSection
         v-model="filterPayload.bankAccounts['Business savings accounts']"

--- a/components/eco-bank/EcoBankFilters.client.vue
+++ b/components/eco-bank/EcoBankFilters.client.vue
@@ -129,7 +129,7 @@
         class="col-span-full"
         name="Business accounts"
       >
-        Business current accounts
+        {{ isBE() ? "Business current accounts" : "Business checking accounts" }}
       </CheckboxSection>
       <CheckboxSection
         v-model="filterPayload.bankAccounts['Business savings accounts']"

--- a/components/eco-bank/features/EcoBankFeaturesList.vue
+++ b/components/eco-bank/features/EcoBankFeaturesList.vue
@@ -2,40 +2,42 @@
   <div
     v-for="(item, key) in features"
     :key="key"
-    class="flex items-center mr-10 my-2"
+    class="flex items-center mr-4 my-2"
   >
-    <svg
-      v-if="item.isChecked"
-      class="flex-none p-1 w-6 h-6 mt-0.5 mr-4 bg-sushi-100 rounded-full text-sushi-500"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M5 13l4 4L19 7"
-      />
-    </svg>
-    <svg
-      v-else
-      class="w-6 h-6 mr-4 text-gray-400"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        d="M6 18L18 6M6 6l12 12"
-      />
-    </svg>
-    <div class="flex-1">
-      <span v-if="item.isChecked && item.text" class="text-gray-900">{{
+  <svg
+    v-if="item.isChecked"
+    class="flex-none p-1 w-6 h-6 mt-0.5 mr-1 bg-sushi-100 rounded-full text-sushi-500"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 16 16" 
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M4.33 8l2.67 2.67L11.67 5.67" 
+    />
+  </svg>
+  <svg
+    v-else
+    class="w-6 h-6 mr-4 text-gray-400"
+    fill="none"
+    stroke="currentColor"
+    viewBox="0 0 16 16" 
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      d="M4 12L12 4M4 4l8 8" 
+    />
+  </svg>
+
+
+    <div class="flex-1 text-sm">
+      <span v-if="item.isChecked && item.text" class="text-gray-900 text-sm">{{
         `${key}: ${item.text}`
       }}</span>
       <span v-else-if="item.isChecked" class="text-gray-700">{{ key }}</span>

--- a/components/eco-bank/features/EcoBankFeaturesList.vue
+++ b/components/eco-bank/features/EcoBankFeaturesList.vue
@@ -4,37 +4,36 @@
     :key="key"
     class="flex items-center mr-4 my-2"
   >
-  <svg
-    v-if="item.isChecked"
-    class="flex-none p-1 w-6 h-6 mt-0.5 mr-1 bg-sushi-100 rounded-full text-sushi-500"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 16 16" 
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M4.33 8l2.67 2.67L11.67 5.67" 
-    />
-  </svg>
-  <svg
-    v-else
-    class="w-6 h-6 mr-4 text-gray-400"
-    fill="none"
-    stroke="currentColor"
-    viewBox="0 0 16 16" 
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      stroke-width="2"
-      d="M4 12L12 4M4 4l8 8" 
-    />
-  </svg>
-
+    <svg
+      v-if="item.isChecked"
+      class="flex-none p-1 w-6 h-6 mt-0.5 mr-1 bg-sushi-100 rounded-full text-sushi-500"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M4.33 8l2.67 2.67L11.67 5.67"
+      />
+    </svg>
+    <svg
+      v-else
+      class="w-6 h-6 mr-4 text-gray-400"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 16 16"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        d="M4 12L12 4M4 4l8 8"
+      />
+    </svg>
 
     <div class="flex-1 text-sm">
       <span v-if="item.isChecked && item.text" class="text-gray-900 text-sm">{{

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -181,7 +181,7 @@ export default defineNuxtConfig({
   },
   vite: {
     plugins: [
-      // process.env.NODE_ENV !== 'test' && eslintPlugin()
+      process.env.NODE_ENV !== 'test' && eslintPlugin()
     ]
   }
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -181,7 +181,7 @@ export default defineNuxtConfig({
   },
   vite: {
     plugins: [
-      process.env.NODE_ENV !== 'test' && eslintPlugin()
+      // process.env.NODE_ENV !== 'test' && eslintPlugin()
     ]
   }
 })

--- a/pages/sustainable-eco-banks/index.vue
+++ b/pages/sustainable-eco-banks/index.vue
@@ -20,6 +20,7 @@
         leave-to-class="opacity-0 scale-y-95"
         mode="out-in"
       >
+      <div v-if="true">
         <div class="flex flex-col md:flex-row">
           <div
             class="lg:w-80 md:sticky mb-4 md:mb-0 top-20 flex-shrink-0 rounded-2xl lg:px-10"
@@ -72,6 +73,7 @@
             </div>
           </div>
         </div>
+      </div>
       </transition>
       <div
         class="prose sm:prose-lg xl:prose-xl mx-auto max-w-4xl xl:max-w-5xl mb-10"
@@ -141,7 +143,17 @@ const loadBanks = async ({
         b.topPick - a.topPick ||
         b.fossilFreeAllianceRating - a.fossilFreeAllianceRating ||
         a.name - b.name
-    )
+      )
+      .map(bank => {
+        console.log(bank)
+        return {
+          ...bank,
+          account_types: bank.bankFeatures.filter(a => ['checking', 'saving', 'credit cards'].includes(a.feature.name?.toLowerCase())),
+          interest_rates: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('interest rates'))?.details ?? '',
+          fdic: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('fdic'))?.details ?? '',
+          other_features: bank.bankFeatures.filter(a => !['checking', 'saving', 'credit cards', 'interest rates', 'business', 'mobile'].filter(x => a.feature.name?.toLowerCase().includes(x)).length > 0)
+        }
+      })  
   loading.value = false
   if (banks.value.length === 0) {
     errorMessage.value =

--- a/pages/sustainable-eco-banks/index.vue
+++ b/pages/sustainable-eco-banks/index.vue
@@ -145,45 +145,12 @@ const loadBanks = async ({
         a.name - b.name
     )
     .map((bank) => {
-      console.log(bank)
-      let accountTypes = ['checking', 'saving', 'credit cards']
-      let checkingName = 'Current'
-
-      if (country.value === 'US') {
-        checkingName = 'Checking'
-      }
-      if (country.value === 'FR' || country.value === 'DE') {
-        accountTypes = ['checking', 'saving']
-      }
       return {
         ...bank,
-        account_types: bank.bankFeatures
-          .filter(a => accountTypes.includes(a.feature.name?.toLowerCase()))
-          ?.map(x =>
-            x.feature.name
-              .replace('checking', checkingName)
-              .replace('saving', 'Savings')
-          ),
         interest_rates:
           bank.bankFeatures.find(a =>
             a.feature.name?.toLowerCase().includes('interest rates')
-          )?.details ?? '',
-        fdic:
-          bank.bankFeatures.find(a =>
-            a.feature.name?.toLowerCase().includes('fdic')
-          )?.details ?? '',
-        other_features: bank.bankFeatures.filter(
-          a =>
-            ![
-              'checking',
-              'saving',
-              'credit cards',
-              'interest rates',
-              'business',
-              'mobile'
-            ].filter(x => a.feature.name?.toLowerCase().includes(x)).length >
-            0
-        )
+          )?.details ?? ''
       }
     })
   loading.value = false

--- a/pages/sustainable-eco-banks/index.vue
+++ b/pages/sustainable-eco-banks/index.vue
@@ -54,7 +54,7 @@
                 :class="[loading ? 'opacity-50 pointer-events-none' : '']"
                 class="transition"
               >
-                <EcoBankCards :list="banks" :is-no-credit="isNoCredit" />
+                <EcoBankCards :list="banks" />
               </div>
 
               <div v-else-if="!loading" class="mt-20">
@@ -146,9 +146,18 @@ const loadBanks = async ({
       )
       .map(bank => {
         console.log(bank)
+        var account_types = ['checking', 'saving', 'credit cards']
+        var checking_name = 'Current'
+
+        if (country.value === 'US') {
+          checking_name = 'Checking'
+        } 
+        if (country.value === 'FR' || country.value === 'DE') {
+          account_types = ['checking', 'saving']
+        }
         return {
           ...bank,
-          account_types: bank.bankFeatures.filter(a => ['checking', 'saving', 'credit cards'].includes(a.feature.name?.toLowerCase())),
+          account_types: bank.bankFeatures.filter(a => account_types.includes(a.feature.name?.toLowerCase()))?.map(x => x.feature.name.replace('checking', checking_name).replace('saving', 'Savings')),
           interest_rates: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('interest rates'))?.details ?? '',
           fdic: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('fdic'))?.details ?? '',
           other_features: bank.bankFeatures.filter(a => !['checking', 'saving', 'credit cards', 'interest rates', 'business', 'mobile'].filter(x => a.feature.name?.toLowerCase().includes(x)).length > 0)
@@ -164,9 +173,6 @@ watch(country, () => {
   banks.value = []
 })
 
-const isNoCredit = computed(() => {
-  return country.value === 'FR' || country.value === 'DE'
-})
 
 const applyFilter = (payload) => {
   loadBanks(payload)

--- a/pages/sustainable-eco-banks/index.vue
+++ b/pages/sustainable-eco-banks/index.vue
@@ -20,60 +20,60 @@
         leave-to-class="opacity-0 scale-y-95"
         mode="out-in"
       >
-      <div v-if="true">
-        <div class="flex flex-col md:flex-row">
-          <div
-            class="lg:w-80 md:sticky mb-4 md:mb-0 top-20 flex-shrink-0 rounded-2xl lg:px-10"
-            style="height: fit-content"
-          >
-            <EcoBankFilters
-              v-if="country"
-              :location="country"
-              @filter="applyFilter"
-            />
-          </div>
-
-          <div class="relative w-full md:ml-6">
-            <LocationSearch v-model="country" class="z-30 mb-8" />
-
-            <div v-if="!country">
-              <h2
-                class="w-full px-5 py-4 bg-gray-100 border border-gray-300 rounded-2xl text-sm"
-              >
-                <div class="font-medium text-gray-600">
-                  No country selected
-                </div>
-                <div class="text-sm text-gray-500">
-                  To continue, please select a country.
-                </div>
-              </h2>
+        <div v-if="true">
+          <div class="flex flex-col md:flex-row">
+            <div
+              class="lg:w-80 md:sticky mb-4 md:mb-0 top-20 flex-shrink-0 rounded-2xl lg:px-10"
+              style="height: fit-content"
+            >
+              <EcoBankFilters
+                v-if="country"
+                :location="country"
+                @filter="applyFilter"
+              />
             </div>
-            <div v-else>
-              <div
-                v-if="banks.length"
-                :class="[loading ? 'opacity-50 pointer-events-none' : '']"
-                class="transition"
-              >
-                <EcoBankCards :list="banks" />
-              </div>
 
-              <div v-else-if="!loading" class="mt-20">
+            <div class="relative w-full md:ml-6">
+              <LocationSearch v-model="country" class="z-30 mb-8" />
+
+              <div v-if="!country">
                 <h2
-                  v-if="errorMessage"
-                  class="text-xl font-semibold mb-4 md:text-center"
+                  class="w-full px-5 py-4 bg-gray-100 border border-gray-300 rounded-2xl text-sm"
                 >
-                  {{ errorMessage }}
+                  <div class="font-medium text-gray-600">
+                    No country selected
+                  </div>
+                  <div class="text-sm text-gray-500">
+                    To continue, please select a country.
+                  </div>
                 </h2>
-                <p class="text-gray-600 mb-8 md:text-center max-w-lg mx-auto">
-                  We’re working hard to increase the number of banks we provide
-                  data on. If you tell us your bank’s name, we’ll email you as
-                  soon as we have a score for it.
-                </p>
+              </div>
+              <div v-else>
+                <div
+                  v-if="banks.length"
+                  :class="[loading ? 'opacity-50 pointer-events-none' : '']"
+                  class="transition"
+                >
+                  <EcoBankCards :list="banks" />
+                </div>
+
+                <div v-else-if="!loading" class="mt-20">
+                  <h2
+                    v-if="errorMessage"
+                    class="text-xl font-semibold mb-4 md:text-center"
+                  >
+                    {{ errorMessage }}
+                  </h2>
+                  <p class="text-gray-600 mb-8 md:text-center max-w-lg mx-auto">
+                    We’re working hard to increase the number of banks we
+                    provide data on. If you tell us your bank’s name, we’ll
+                    email you as soon as we have a score for it.
+                  </p>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
       </transition>
       <div
         class="prose sm:prose-lg xl:prose-xl mx-auto max-w-4xl xl:max-w-5xl mb-10"
@@ -93,38 +93,38 @@
 </template>
 
 <script setup>
-import { defineSliceZoneComponents } from '@prismicio/vue'
-import LocationSearch from '@/components/forms/location/LocationSearch.vue'
+import { defineSliceZoneComponents } from "@prismicio/vue";
+import LocationSearch from "@/components/forms/location/LocationSearch.vue";
 
-import { components } from '~~/slices'
-const sliceComps = ref(defineSliceZoneComponents(components))
+import { components } from "~~/slices";
+const sliceComps = ref(defineSliceZoneComponents(components));
 
 // useHeadHelper('Find Eco Banks & Sustainable Banks In Your Area - Bank.Green', 'Find and compare the service offerings of ethical and sustainable banks.')
 
-const { client } = usePrismic()
+const { client } = usePrismic();
 
-const { data: ecobanks } = await useAsyncData('ecobanks', () =>
-  client.getSingle('ecobankspage', {
-    fetchLinks: ['accordionitem.title', 'accordionitem.slices']
-  })
-)
-usePrismicSEO(ecobanks?.value?.data)
+const { data: ecobanks } = await useAsyncData("ecobanks", () =>
+  client.getSingle("ecobankspage", {
+    fetchLinks: ["accordionitem.title", "accordionitem.slices"],
+  }),
+);
+usePrismicSEO(ecobanks?.value?.data);
 
-const { country } = useCountry()
+const { country } = useCountry();
 
-const banks = ref([])
-const loading = ref(false)
-const errorMessage = ref(null)
+const banks = ref([]);
+const loading = ref(false);
+const errorMessage = ref(null);
 const loadBanks = async ({
   regions,
   subregions,
   fossilFreeAlliance,
   topPick,
-  features
+  features,
 }) => {
-  loading.value = true
+  loading.value = true;
   if (!country.value) {
-    return
+    return;
   }
   const result = await getBanksListWithFilter({
     country: country.value,
@@ -132,49 +132,71 @@ const loadBanks = async ({
     subregions,
     topPick,
     fossilFreeAlliance,
-    features
-  })
+    features,
+  });
   banks.value = result
     // filter show_on_sustainable_banks_page
-    .filter(a => a.showOnSustainableBanksPage)
+    .filter((a) => a.showOnSustainableBanksPage)
     // sort by top_pick first, then fossil_free_alliance_rating, then by name
     .sort(
       (a, b) =>
         b.topPick - a.topPick ||
         b.fossilFreeAllianceRating - a.fossilFreeAllianceRating ||
-        a.name - b.name
-      )
-      .map(bank => {
-        console.log(bank)
-        var account_types = ['checking', 'saving', 'credit cards']
-        var checking_name = 'Current'
+        a.name - b.name,
+    )
+    .map((bank) => {
+      console.log(bank);
+      let account_types = ["checking", "saving", "credit cards"];
+      let checking_name = "Current";
 
-        if (country.value === 'US') {
-          checking_name = 'Checking'
-        } 
-        if (country.value === 'FR' || country.value === 'DE') {
-          account_types = ['checking', 'saving']
-        }
-        return {
-          ...bank,
-          account_types: bank.bankFeatures.filter(a => account_types.includes(a.feature.name?.toLowerCase()))?.map(x => x.feature.name.replace('checking', checking_name).replace('saving', 'Savings')),
-          interest_rates: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('interest rates'))?.details ?? '',
-          fdic: bank.bankFeatures.find(a => a.feature.name?.toLowerCase().includes('fdic'))?.details ?? '',
-          other_features: bank.bankFeatures.filter(a => !['checking', 'saving', 'credit cards', 'interest rates', 'business', 'mobile'].filter(x => a.feature.name?.toLowerCase().includes(x)).length > 0)
-        }
-      })  
-  loading.value = false
+      if (country.value === "US") {
+        checking_name = "Checking";
+      }
+      if (country.value === "FR" || country.value === "DE") {
+        account_types = ["checking", "saving"];
+      }
+      return {
+        ...bank,
+        account_types: bank.bankFeatures
+          .filter((a) => account_types.includes(a.feature.name?.toLowerCase()))
+          ?.map((x) =>
+            x.feature.name
+              .replace("checking", checking_name)
+              .replace("saving", "Savings"),
+          ),
+        interest_rates:
+          bank.bankFeatures.find((a) =>
+            a.feature.name?.toLowerCase().includes("interest rates"),
+          )?.details ?? "",
+        fdic:
+          bank.bankFeatures.find((a) =>
+            a.feature.name?.toLowerCase().includes("fdic"),
+          )?.details ?? "",
+        other_features: bank.bankFeatures.filter(
+          (a) =>
+            ![
+              "checking",
+              "saving",
+              "credit cards",
+              "interest rates",
+              "business",
+              "mobile",
+            ].filter((x) => a.feature.name?.toLowerCase().includes(x)).length >
+            0,
+        ),
+      };
+    });
+  loading.value = false;
   if (banks.value.length === 0) {
     errorMessage.value =
-      "Sorry, we don't have any banks that meet the required filter."
+      "Sorry, we don't have any banks that meet the required filter.";
   } // TODO: should put this string in Prismic
-}
+};
 watch(country, () => {
-  banks.value = []
-})
-
+  banks.value = [];
+});
 
 const applyFilter = (payload) => {
-  loadBanks(payload)
-}
+  loadBanks(payload);
+};
 </script>

--- a/pages/sustainable-eco-banks/index.vue
+++ b/pages/sustainable-eco-banks/index.vue
@@ -93,38 +93,38 @@
 </template>
 
 <script setup>
-import { defineSliceZoneComponents } from "@prismicio/vue";
-import LocationSearch from "@/components/forms/location/LocationSearch.vue";
+import { defineSliceZoneComponents } from '@prismicio/vue'
+import LocationSearch from '@/components/forms/location/LocationSearch.vue'
 
-import { components } from "~~/slices";
-const sliceComps = ref(defineSliceZoneComponents(components));
+import { components } from '~~/slices'
+const sliceComps = ref(defineSliceZoneComponents(components))
 
 // useHeadHelper('Find Eco Banks & Sustainable Banks In Your Area - Bank.Green', 'Find and compare the service offerings of ethical and sustainable banks.')
 
-const { client } = usePrismic();
+const { client } = usePrismic()
 
-const { data: ecobanks } = await useAsyncData("ecobanks", () =>
-  client.getSingle("ecobankspage", {
-    fetchLinks: ["accordionitem.title", "accordionitem.slices"],
-  }),
-);
-usePrismicSEO(ecobanks?.value?.data);
+const { data: ecobanks } = await useAsyncData('ecobanks', () =>
+  client.getSingle('ecobankspage', {
+    fetchLinks: ['accordionitem.title', 'accordionitem.slices']
+  })
+)
+usePrismicSEO(ecobanks?.value?.data)
 
-const { country } = useCountry();
+const { country } = useCountry()
 
-const banks = ref([]);
-const loading = ref(false);
-const errorMessage = ref(null);
+const banks = ref([])
+const loading = ref(false)
+const errorMessage = ref(null)
 const loadBanks = async ({
   regions,
   subregions,
   fossilFreeAlliance,
   topPick,
-  features,
+  features
 }) => {
-  loading.value = true;
+  loading.value = true
   if (!country.value) {
-    return;
+    return
   }
   const result = await getBanksListWithFilter({
     country: country.value,
@@ -132,71 +132,71 @@ const loadBanks = async ({
     subregions,
     topPick,
     fossilFreeAlliance,
-    features,
-  });
+    features
+  })
   banks.value = result
     // filter show_on_sustainable_banks_page
-    .filter((a) => a.showOnSustainableBanksPage)
+    .filter(a => a.showOnSustainableBanksPage)
     // sort by top_pick first, then fossil_free_alliance_rating, then by name
     .sort(
       (a, b) =>
         b.topPick - a.topPick ||
         b.fossilFreeAllianceRating - a.fossilFreeAllianceRating ||
-        a.name - b.name,
+        a.name - b.name
     )
     .map((bank) => {
-      console.log(bank);
-      let account_types = ["checking", "saving", "credit cards"];
-      let checking_name = "Current";
+      console.log(bank)
+      let accountTypes = ['checking', 'saving', 'credit cards']
+      let checkingName = 'Current'
 
-      if (country.value === "US") {
-        checking_name = "Checking";
+      if (country.value === 'US') {
+        checkingName = 'Checking'
       }
-      if (country.value === "FR" || country.value === "DE") {
-        account_types = ["checking", "saving"];
+      if (country.value === 'FR' || country.value === 'DE') {
+        accountTypes = ['checking', 'saving']
       }
       return {
         ...bank,
         account_types: bank.bankFeatures
-          .filter((a) => account_types.includes(a.feature.name?.toLowerCase()))
-          ?.map((x) =>
+          .filter(a => accountTypes.includes(a.feature.name?.toLowerCase()))
+          ?.map(x =>
             x.feature.name
-              .replace("checking", checking_name)
-              .replace("saving", "Savings"),
+              .replace('checking', checkingName)
+              .replace('saving', 'Savings')
           ),
         interest_rates:
-          bank.bankFeatures.find((a) =>
-            a.feature.name?.toLowerCase().includes("interest rates"),
-          )?.details ?? "",
+          bank.bankFeatures.find(a =>
+            a.feature.name?.toLowerCase().includes('interest rates')
+          )?.details ?? '',
         fdic:
-          bank.bankFeatures.find((a) =>
-            a.feature.name?.toLowerCase().includes("fdic"),
-          )?.details ?? "",
+          bank.bankFeatures.find(a =>
+            a.feature.name?.toLowerCase().includes('fdic')
+          )?.details ?? '',
         other_features: bank.bankFeatures.filter(
-          (a) =>
+          a =>
             ![
-              "checking",
-              "saving",
-              "credit cards",
-              "interest rates",
-              "business",
-              "mobile",
-            ].filter((x) => a.feature.name?.toLowerCase().includes(x)).length >
-            0,
-        ),
-      };
-    });
-  loading.value = false;
+              'checking',
+              'saving',
+              'credit cards',
+              'interest rates',
+              'business',
+              'mobile'
+            ].filter(x => a.feature.name?.toLowerCase().includes(x)).length >
+            0
+        )
+      }
+    })
+  loading.value = false
   if (banks.value.length === 0) {
     errorMessage.value =
-      "Sorry, we don't have any banks that meet the required filter.";
+      "Sorry, we don't have any banks that meet the required filter."
   } // TODO: should put this string in Prismic
-};
+}
 watch(country, () => {
-  banks.value = [];
-});
+  banks.value = []
+})
 
 const applyFilter = (payload) => {
-  loadBanks(payload);
-};
+  loadBanks(payload)
+}
 </script>

--- a/slices/AccordionSlice/index.vue
+++ b/slices/AccordionSlice/index.vue
@@ -20,7 +20,7 @@
         leave-to-class="opacity-0 scale-y-95"
         mode="out-in"
       >
-        <h2 class="font-semibold md:!text-lg text-gray-700 mr-4">
+        <h2 v-if="true" class="font-semibold md:!text-lg text-gray-700 mr-4">
           <span v-if="slice.variation === 'default'">{{
             slice.primary?.contentlink?.data.title
           }}</span>

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -108,6 +108,9 @@ export async function getBanksListWithFilter ({
           brands(country: $country, first: $first, topPick: $topPick, fossilFreeAlliance: $fossilFreeAlliance, features: $features, regions: $regions, subregions: $subregions) {
               edges {
                   node {
+                      countries {
+                        code
+                      }
                       name
                       tag
                       website,

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -1,14 +1,14 @@
-import { get } from "./backend";
+import { get } from './backend'
 
-const gqlUrl = "https://data.bank.green/graphql"; // fallback, should be in env
-const options = {};
+const gqlUrl = 'https://data.bank.green/graphql' // fallback, should be in env
+const options = {}
 
-async function callBackend(query, variables) {
-  const queryParam = encodeURIComponent(query);
-  const variablesParam = encodeURIComponent(JSON.stringify(variables));
-  const url = `${useRuntimeConfig().public.DATA_URL || gqlUrl}?query=${queryParam}&variables=${variablesParam}`;
-  const res = await $fetch(url, options);
-  return res;
+async function callBackend (query, variables) {
+  const queryParam = encodeURIComponent(query)
+  const variablesParam = encodeURIComponent(JSON.stringify(variables))
+  const url = `${useRuntimeConfig().public.DATA_URL || gqlUrl}?query=${queryParam}&variables=${variablesParam}`
+  const res = await $fetch(url, options)
+  return res
 }
 
 const commentaryFields = `{
@@ -31,7 +31,7 @@ const commentaryFields = `{
         name
         prismicApiId
     }
-  }`;
+  }`
 
 const bankFeaturesFields = `{
     offered
@@ -39,14 +39,14 @@ const bankFeaturesFields = `{
         name
     }
     details
-}`;
+}`
 
-export async function getBanksList({
+export async function getBanksList ({
   country,
   topOnly = false,
   recommendedOnly = true,
   first = 3,
-  isEmbrace = false,
+  isEmbrace = false
 }) {
   const brandsQuery = `
         query BrandsQuery($country: String, $recommendedOnly: Boolean, $rating: [String], $first: Int, $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
@@ -62,7 +62,7 @@ export async function getBanksList({
                     }
                 }
             }
-        }`;
+        }`
   const embraceBrandsQuery = `
       query EmbraceBrandQuery {
           brandsFilteredByEmbraceCampaign(id: 1){
@@ -70,40 +70,40 @@ export async function getBanksList({
             website
             tag
         }
-      }`;
-  const query = isEmbrace ? embraceBrandsQuery : brandsQuery;
+      }`
+  const query = isEmbrace ? embraceBrandsQuery : brandsQuery
 
-  const variables = { country };
+  const variables = { country }
   if (topOnly) {
-    variables.recommendedOnly = recommendedOnly;
-    variables.withCommentary = true; // pull a lot more details in
-    variables.withFeatures = true;
-    variables.first = first; // due to data entry errors in the backend, we cannot rely on there only being three
+    variables.recommendedOnly = recommendedOnly
+    variables.withCommentary = true // pull a lot more details in
+    variables.withFeatures = true
+    variables.first = first // due to data entry errors in the backend, we cannot rely on there only being three
   }
 
-  const json = await callBackend(query, variables);
+  const json = await callBackend(query, variables)
   let banks = isEmbrace
     ? json.data.brandsFilteredByEmbraceCampaign
-    : json.data.brands.edges.map((o) => o.node);
+    : json.data.brands.edges.map(o => o.node)
   if (topOnly) {
     banks = banks.map((b) => {
       return {
         ...b,
         ...b.commentary,
-        rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0,
-      };
-    });
+        rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0
+      }
+    })
   }
-  return banks;
+  return banks
 }
 
-export async function getBanksListWithFilter({
+export async function getBanksListWithFilter ({
   country,
   regions,
   subregions,
   topPick,
   fossilFreeAlliance,
-  features,
+  features
 }) {
   const brandsQuery = `
       query BrandsQuery($country: String, $first: Int, $topPick: Boolean, $fossilFreeAlliance: Boolean, $features: [String], $regions: [String], $subregions: [String], $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
@@ -127,7 +127,7 @@ export async function getBanksListWithFilter({
                   }
               }
           }
-      }`;
+      }`
 
   const variables = {
     country,
@@ -138,36 +138,36 @@ export async function getBanksListWithFilter({
     features,
     first: 300,
     withCommentary: true,
-    withFeatures: true,
-  };
+    withFeatures: true
+  }
 
-  const json = await callBackend(brandsQuery, variables);
-  let banks = json.data.brands.edges.map((o) => o.node);
+  const json = await callBackend(brandsQuery, variables)
+  let banks = json.data.brands.edges.map(o => o.node)
   banks = banks.map((b) => {
     return {
       ...b,
       ...b.commentary,
-      rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0,
-    };
-  });
-  return banks;
+      rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0
+    }
+  })
+  return banks
 }
 
-export async function getCountry() {
-  const cachedCountry = useCookie("bg.country.suggested", {
-    default: () => "",
-  });
+export async function getCountry () {
+  const cachedCountry = useCookie('bg.country.suggested', {
+    default: () => ''
+  })
 
   if (!cachedCountry.value) {
-    const res = await get("/getCountry");
+    const res = await get('/getCountry')
     if (res.country) {
-      cachedCountry.value = res.country;
+      cachedCountry.value = res.country
     }
   }
-  return cachedCountry;
+  return cachedCountry
 }
 
-export async function getBankDetail(bankTag) {
+export async function getBankDetail (bankTag) {
   const brandQuery = `
     query BrandByTagQuery($tag: String!) {
         brand(tag: $tag) {
@@ -181,20 +181,20 @@ export async function getBankDetail(bankTag) {
           }
         }
       }
-    `;
+    `
   const variables = {
-    tag: bankTag,
-  };
+    tag: bankTag
+  }
 
-  const json = await callBackend(brandQuery, variables);
+  const json = await callBackend(brandQuery, variables)
   if (!json?.data?.brand) {
-    return {};
+    return {}
   }
   const bank = {
     ...json.data.brand,
     ...json.data.brand.commentary,
-    bankFatures: json.data.brand.bankFeatures,
-  };
-  bank.rating = bank.ratingInherited?.toLowerCase();
-  return bank;
+    bankFatures: json.data.brand.bankFeatures
+  }
+  bank.rating = bank.ratingInherited?.toLowerCase()
+  return bank
 }

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -1,14 +1,14 @@
-import { get } from './backend'
+import { get } from "./backend";
 
-const gqlUrl = 'https://data.bank.green/graphql' // fallback, should be in env
-const options = {}
+const gqlUrl = "https://data.bank.green/graphql"; // fallback, should be in env
+const options = {};
 
-async function callBackend (query, variables) {
-  const queryParam = encodeURIComponent(query)
-  const variablesParam = encodeURIComponent(JSON.stringify(variables))
-  const url = `${useRuntimeConfig().public.DATA_URL || gqlUrl}?query=${queryParam}&variables=${variablesParam}`
-  const res = await $fetch(url, options)
-  return res
+async function callBackend(query, variables) {
+  const queryParam = encodeURIComponent(query);
+  const variablesParam = encodeURIComponent(JSON.stringify(variables));
+  const url = `${useRuntimeConfig().public.DATA_URL || gqlUrl}?query=${queryParam}&variables=${variablesParam}`;
+  const res = await $fetch(url, options);
+  return res;
 }
 
 const commentaryFields = `{
@@ -31,7 +31,7 @@ const commentaryFields = `{
         name
         prismicApiId
     }
-  }`
+  }`;
 
 const bankFeaturesFields = `{
     offered
@@ -39,14 +39,14 @@ const bankFeaturesFields = `{
         name
     }
     details
-}`
+}`;
 
-export async function getBanksList ({
+export async function getBanksList({
   country,
   topOnly = false,
   recommendedOnly = true,
   first = 3,
-  isEmbrace = false
+  isEmbrace = false,
 }) {
   const brandsQuery = `
         query BrandsQuery($country: String, $recommendedOnly: Boolean, $rating: [String], $first: Int, $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
@@ -62,7 +62,7 @@ export async function getBanksList ({
                     }
                 }
             }
-        }`
+        }`;
   const embraceBrandsQuery = `
       query EmbraceBrandQuery {
           brandsFilteredByEmbraceCampaign(id: 1){
@@ -70,38 +70,40 @@ export async function getBanksList ({
             website
             tag
         }
-      }`
-  const query = isEmbrace ? embraceBrandsQuery : brandsQuery
+      }`;
+  const query = isEmbrace ? embraceBrandsQuery : brandsQuery;
 
-  const variables = { country }
+  const variables = { country };
   if (topOnly) {
-    variables.recommendedOnly = recommendedOnly
-    variables.withCommentary = true // pull a lot more details in
-    variables.withFeatures = true
-    variables.first = first // due to data entry errors in the backend, we cannot rely on there only being three
+    variables.recommendedOnly = recommendedOnly;
+    variables.withCommentary = true; // pull a lot more details in
+    variables.withFeatures = true;
+    variables.first = first; // due to data entry errors in the backend, we cannot rely on there only being three
   }
 
-  const json = await callBackend(query, variables)
-  let banks = isEmbrace ? json.data.brandsFilteredByEmbraceCampaign : json.data.brands.edges.map(o => o.node)
+  const json = await callBackend(query, variables);
+  let banks = isEmbrace
+    ? json.data.brandsFilteredByEmbraceCampaign
+    : json.data.brands.edges.map((o) => o.node);
   if (topOnly) {
     banks = banks.map((b) => {
       return {
         ...b,
         ...b.commentary,
-        rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0
-      }
-    })
+        rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0,
+      };
+    });
   }
-  return banks
+  return banks;
 }
 
-export async function getBanksListWithFilter ({
+export async function getBanksListWithFilter({
   country,
   regions,
   subregions,
   topPick,
   fossilFreeAlliance,
-  features
+  features,
 }) {
   const brandsQuery = `
       query BrandsQuery($country: String, $first: Int, $topPick: Boolean, $fossilFreeAlliance: Boolean, $features: [String], $regions: [String], $subregions: [String], $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
@@ -125,7 +127,7 @@ export async function getBanksListWithFilter ({
                   }
               }
           }
-      }`
+      }`;
 
   const variables = {
     country,
@@ -136,36 +138,36 @@ export async function getBanksListWithFilter ({
     features,
     first: 300,
     withCommentary: true,
-    withFeatures: true
-  }
+    withFeatures: true,
+  };
 
-  const json = await callBackend(brandsQuery, variables)
-  let banks = json.data.brands.edges.map(o => o.node)
+  const json = await callBackend(brandsQuery, variables);
+  let banks = json.data.brands.edges.map((o) => o.node);
   banks = banks.map((b) => {
     return {
       ...b,
       ...b.commentary,
-      rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0
-    }
-  })
-  return banks
+      rating: b.commentary?.ratingInherited?.toLowerCase() ?? 0,
+    };
+  });
+  return banks;
 }
 
-export async function getCountry () {
-  const cachedCountry = useCookie('bg.country.suggested', {
-    default: () => ''
-  })
+export async function getCountry() {
+  const cachedCountry = useCookie("bg.country.suggested", {
+    default: () => "",
+  });
 
   if (!cachedCountry.value) {
-    const res = await get('/getCountry')
+    const res = await get("/getCountry");
     if (res.country) {
-      cachedCountry.value = res.country
+      cachedCountry.value = res.country;
     }
   }
-  return cachedCountry
+  return cachedCountry;
 }
 
-export async function getBankDetail (bankTag) {
+export async function getBankDetail(bankTag) {
   const brandQuery = `
     query BrandByTagQuery($tag: String!) {
         brand(tag: $tag) {
@@ -179,18 +181,20 @@ export async function getBankDetail (bankTag) {
           }
         }
       }
-    `
+    `;
   const variables = {
-    tag: bankTag
-  }
+    tag: bankTag,
+  };
 
-  const json = await callBackend(brandQuery, variables)
-  if (!json?.data?.brand) { return {} }
+  const json = await callBackend(brandQuery, variables);
+  if (!json?.data?.brand) {
+    return {};
+  }
   const bank = {
     ...json.data.brand,
     ...json.data.brand.commentary,
-    bankFatures: json.data.brand.bankFeatures
-  }
-  bank.rating = bank.ratingInherited?.toLowerCase()
-  return bank
+    bankFatures: json.data.brand.bankFeatures,
+  };
+  bank.rating = bank.ratingInherited?.toLowerCase();
+  return bank;
 }

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -1,74 +1,74 @@
 // these functions transform the data from the backend into the format used by our frontend templates
-export default function getFeatures (bankFeatures, summary = false) {
-  const { isBE } = useCountry()
+export default function getFeatures(bankFeatures, summary = false) {
+  const { isBE } = useCountry();
   if (!bankFeatures) {
-    return {}
+    return {};
   }
-  const checkingName =  isBE() ? 'Current' : 'Checking'
+  const checkingName = isBE() ? "Current" : "Checking";
   // features in this dict will show an x if they are not available for a bank
   const mainFeaturesDict = {
-    'Mobile banking': 'Mobile Banking',
-    'Free ATM network': 'Free ATM Network',
-    'No overdraft fee': 'No Overdraft Fee',
-    'No account maintenance fee': 'No Account Maintenance Fees',
-  }
+    "Mobile banking": "Mobile Banking",
+    "Free ATM network": "Free ATM Network",
+    "No overdraft fee": "No Overdraft Fee",
+    "No account maintenance fee": "No Account Maintenance Fees",
+  };
 
   var featureDict = {
-    checking: checkingName + ' Accounts',
-    saving: 'Savings Accounts',
-    'Interest rates': 'Interest Rates',
-    'Business accounts': 'Business ' + checkingName + ' Accounts',
-    'Small business lending': 'Small Business Lending',
-    'Credit cards': 'Credit Cards',
-    'Mortgages or Loans': 'Mortgage or Loan Options',
-    'Deposit protection': 'Deposit Protection',
-    'Corporate Lending': 'Corporate Lending',
-    'Business Savings Accounts': 'Business Savings Accounts'
-  }
+    checking: checkingName + " Accounts",
+    saving: "Savings Accounts",
+    "Interest rates": "Interest Rates",
+    "Business accounts": "Business " + checkingName + " Accounts",
+    "Small business lending": "Small Business Lending",
+    "Credit cards": "Credit Cards",
+    "Mortgages or Loans": "Mortgage or Loan Options",
+    "Deposit protection": "Deposit Protection",
+    "Corporate Lending": "Corporate Lending",
+    "Business Savings Accounts": "Business Savings Accounts",
+  };
 
   // initialize result object with all false
-  const result = {}
+  const result = {};
   Object.values(mainFeaturesDict).forEach((v) => {
-    result[v] = { isChecked: false, hide: false }
-  })
+    result[v] = { isChecked: false, hide: false };
+  });
   Object.values(featureDict).forEach((v) => {
-    result[v] = { isChecked: false, hide: true }
-  })
+    result[v] = { isChecked: false, hide: true };
+  });
 
   const allFeatures = {
     ...mainFeaturesDict,
-    ...featureDict
-  }
+    ...featureDict,
+  };
 
   for (const bankFeature of bankFeatures) {
     if (allFeatures[bankFeature.feature.name]) {
       // it's a feature we're interested in
-      const displayFeature = getDisplayFeature(bankFeature, summary)
-      result[allFeatures[bankFeature.feature.name]] = displayFeature
+      const displayFeature = getDisplayFeature(bankFeature, summary);
+      result[allFeatures[bankFeature.feature.name]] = displayFeature;
     } else {
-      const displayFeature = getDisplayFeature(bankFeature, summary)
-      result[bankFeature.feature.name] = displayFeature
+      const displayFeature = getDisplayFeature(bankFeature, summary);
+      result[bankFeature.feature.name] = displayFeature;
     }
   }
-  console.log(result)
-  return result
+  console.log(result);
+  return result;
 }
 
-function getDisplayFeature (bankFeature, summary) {
+function getDisplayFeature(bankFeature, summary) {
   if (bankFeature.details) {
     return {
       isChecked: true,
-      text: summary ? bankFeature.name : bankFeature.details
-    }
+      text: summary ? bankFeature.name : bankFeature.details,
+    };
   }
 
-  if (bankFeature.offered.toUpperCase() === 'YES') {
+  if (bankFeature.offered.toUpperCase() === "YES") {
     return {
-      isChecked: true
-    }
+      isChecked: true,
+    };
   }
 
   return {
-    isChecked: false
-  }
+    isChecked: false,
+  };
 }

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -1,20 +1,23 @@
 // these functions transform the data from the backend into the format used by our frontend templates
-export default function getFeatures (bankFeatures) {
+export default function getFeatures (bankFeatures, summary = false) {
   const { isBE } = useCountry()
   if (!bankFeatures) {
     return {}
   }
-
+  const checkingName =  isBE() ? 'Current' : 'Checking'
   // features in this dict will show an x if they are not available for a bank
-  const featureDict = {
+  const mainFeaturesDict = {
     'Mobile banking': 'Mobile Banking',
     'Free ATM network': 'Free ATM Network',
     'No overdraft fee': 'No Overdraft Fee',
     'No account maintenance fee': 'No Account Maintenance Fees',
-    checking: isBE() ? 'Current Accounts' : 'Checking Accounts',
+  }
+
+  var featureDict = {
+    checking: checkingName + ' Accounts',
     saving: 'Savings Accounts',
     'Interest rates': 'Interest Rates',
-    'Business accounts': 'Business Current Accounts',
+    'Business accounts': 'Business ' + checkingName + ' Accounts',
     'Small business lending': 'Small Business Lending',
     'Credit cards': 'Credit Cards',
     'Mortgages or Loans': 'Mortgage or Loan Options',
@@ -25,29 +28,37 @@ export default function getFeatures (bankFeatures) {
 
   // initialize result object with all false
   const result = {}
+  Object.values(mainFeaturesDict).forEach((v) => {
+    result[v] = { isChecked: false, hide: false }
+  })
   Object.values(featureDict).forEach((v) => {
-    result[v] = { isChecked: false }
+    result[v] = { isChecked: false, hide: true }
   })
 
+  const allFeatures = {
+    ...mainFeaturesDict,
+    ...featureDict
+  }
+
   for (const bankFeature of bankFeatures) {
-    if (featureDict[bankFeature.feature.name]) {
+    if (allFeatures[bankFeature.feature.name]) {
       // it's a feature we're interested in
-      const displayFeature = getDisplayFeature(bankFeature)
-      result[featureDict[bankFeature.feature.name]] = displayFeature
+      const displayFeature = getDisplayFeature(bankFeature, summary)
+      result[allFeatures[bankFeature.feature.name]] = displayFeature
     } else {
-      const displayFeature = getDisplayFeature(bankFeature)
+      const displayFeature = getDisplayFeature(bankFeature, summary)
       result[bankFeature.feature.name] = displayFeature
     }
   }
-
+  console.log(result)
   return result
 }
 
-function getDisplayFeature (bankFeature) {
+function getDisplayFeature (bankFeature, summary) {
   if (bankFeature.details) {
     return {
       isChecked: true,
-      text: bankFeature.details
+      text: summary ? bankFeature.name : bankFeature.details
     }
   }
 

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -49,7 +49,6 @@ export default function getFeatures (bankFeatures, summary = false) {
       result[bankFeature.feature.name] = displayFeature
     }
   }
-  console.log(result)
   return result
 }
 

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -16,14 +16,13 @@ export default function getFeatures (bankFeatures, summary = false) {
   const featureDict = {
     checking: checkingName + ' Accounts',
     saving: 'Savings Accounts',
-    'Interest rates': 'Interest Rates',
     'Business accounts': 'Business ' + checkingName + ' Accounts',
     'Small business lending': 'Small Business Lending',
-    'Credit cards': 'Credit Cards',
     'Mortgages or Loans': 'Mortgage or Loan Options',
     'Deposit protection': 'Deposit Protection',
     'Corporate Lending': 'Corporate Lending',
-    'Business Savings Accounts': 'Business Savings Accounts'
+    'Business Savings Accounts': 'Business Savings Accounts',
+    'Credit cards': 'Credit Cards'
   }
 
   // initialize result object with all false

--- a/utils/getFeatures.js
+++ b/utils/getFeatures.js
@@ -1,74 +1,74 @@
 // these functions transform the data from the backend into the format used by our frontend templates
-export default function getFeatures(bankFeatures, summary = false) {
-  const { isBE } = useCountry();
+export default function getFeatures (bankFeatures, summary = false) {
+  const { isBE } = useCountry()
   if (!bankFeatures) {
-    return {};
+    return {}
   }
-  const checkingName = isBE() ? "Current" : "Checking";
+  const checkingName = isBE() ? 'Current' : 'Checking'
   // features in this dict will show an x if they are not available for a bank
   const mainFeaturesDict = {
-    "Mobile banking": "Mobile Banking",
-    "Free ATM network": "Free ATM Network",
-    "No overdraft fee": "No Overdraft Fee",
-    "No account maintenance fee": "No Account Maintenance Fees",
-  };
+    'Mobile banking': 'Mobile Banking',
+    'Free ATM network': 'Free ATM Network',
+    'No overdraft fee': 'No Overdraft Fee',
+    'No account maintenance fee': 'No Account Maintenance Fees'
+  }
 
-  var featureDict = {
-    checking: checkingName + " Accounts",
-    saving: "Savings Accounts",
-    "Interest rates": "Interest Rates",
-    "Business accounts": "Business " + checkingName + " Accounts",
-    "Small business lending": "Small Business Lending",
-    "Credit cards": "Credit Cards",
-    "Mortgages or Loans": "Mortgage or Loan Options",
-    "Deposit protection": "Deposit Protection",
-    "Corporate Lending": "Corporate Lending",
-    "Business Savings Accounts": "Business Savings Accounts",
-  };
+  const featureDict = {
+    checking: checkingName + ' Accounts',
+    saving: 'Savings Accounts',
+    'Interest rates': 'Interest Rates',
+    'Business accounts': 'Business ' + checkingName + ' Accounts',
+    'Small business lending': 'Small Business Lending',
+    'Credit cards': 'Credit Cards',
+    'Mortgages or Loans': 'Mortgage or Loan Options',
+    'Deposit protection': 'Deposit Protection',
+    'Corporate Lending': 'Corporate Lending',
+    'Business Savings Accounts': 'Business Savings Accounts'
+  }
 
   // initialize result object with all false
-  const result = {};
+  const result = {}
   Object.values(mainFeaturesDict).forEach((v) => {
-    result[v] = { isChecked: false, hide: false };
-  });
+    result[v] = { isChecked: false, hide: false }
+  })
   Object.values(featureDict).forEach((v) => {
-    result[v] = { isChecked: false, hide: true };
-  });
+    result[v] = { isChecked: false, hide: true }
+  })
 
   const allFeatures = {
     ...mainFeaturesDict,
-    ...featureDict,
-  };
+    ...featureDict
+  }
 
   for (const bankFeature of bankFeatures) {
     if (allFeatures[bankFeature.feature.name]) {
       // it's a feature we're interested in
-      const displayFeature = getDisplayFeature(bankFeature, summary);
-      result[allFeatures[bankFeature.feature.name]] = displayFeature;
+      const displayFeature = getDisplayFeature(bankFeature, summary)
+      result[allFeatures[bankFeature.feature.name]] = displayFeature
     } else {
-      const displayFeature = getDisplayFeature(bankFeature, summary);
-      result[bankFeature.feature.name] = displayFeature;
+      const displayFeature = getDisplayFeature(bankFeature, summary)
+      result[bankFeature.feature.name] = displayFeature
     }
   }
-  console.log(result);
-  return result;
+  console.log(result)
+  return result
 }
 
-function getDisplayFeature(bankFeature, summary) {
+function getDisplayFeature (bankFeature, summary) {
   if (bankFeature.details) {
     return {
       isChecked: true,
-      text: summary ? bankFeature.name : bankFeature.details,
-    };
+      text: summary ? bankFeature.name : bankFeature.details
+    }
   }
 
-  if (bankFeature.offered.toUpperCase() === "YES") {
+  if (bankFeature.offered.toUpperCase() === 'YES') {
     return {
-      isChecked: true,
-    };
+      isChecked: true
+    }
   }
 
   return {
-    isChecked: false,
-  };
+    isChecked: false
+  }
 }


### PR DESCRIPTION
Trying out a few UI improvements to the bank cards, since they are currently very hard to read due to the mixed data and overwhelm of how many checkboxes there are.
- seperate account types into a seperate section
- include the bank rating
- show the interest rate more prominently
- use a banner for top pick
- reintroduce the disabled checkboxes now that there are fewer features

Still needs a bit of cleanup but this is sufficient as a demo of these improvements

New:
![image](https://github.com/user-attachments/assets/e7d3d7c7-dd1e-4ff8-b872-246b3911afe9)


Existing: 
![image](https://github.com/user-attachments/assets/20af2c73-6e44-45af-856c-57dd96294393)
