### PR TITLE
Update sustainable banks query to only retrieve relevant banks

### DIFF
--- a/utils/banks.js
+++ b/utils/banks.js
@@ -96,12 +96,12 @@ export async function getBanksList ({
 }
 
 export async function getBanksListWithFilter ({
-  country = '',
-  regions = [],
-  subregions = [],
-  topPick = null,
-  fossilFreeAlliance = null,
-  features = null,
+  country,
+  regions,
+  subregions,
+  topPick,
+  fossilFreeAlliance,
+  features,
   sustainableOnly = true
 }) {
   const brandsQuery = `

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -132,7 +132,7 @@ export async function getBanksListWithFilter ({
     topPick,
     fossilFreeAlliance,
     features,
-    first: 500,
+    first: 300,
     withCommentary: true,
     withFeatures: true,
     sustainableOnly: sustainableOnly

--- a/utils/banks.js
+++ b/utils/banks.js
@@ -23,7 +23,7 @@ const commentaryFields = `{
     topPick,
     fossilFreeAlliance,
     fossilFreeAllianceRating,
-    showOnSustainableBanksPage
+    showOnSustainableBanksPage,
     institutionType {
         name
     }
@@ -96,16 +96,17 @@ export async function getBanksList ({
 }
 
 export async function getBanksListWithFilter ({
-  country,
-  regions,
-  subregions,
-  topPick,
-  fossilFreeAlliance,
-  features
+  country = '',
+  regions = [],
+  subregions = [],
+  topPick = null,
+  fossilFreeAlliance = null,
+  features = null,
+  sustainableOnly = true
 }) {
   const brandsQuery = `
-      query BrandsQuery($country: String, $first: Int, $topPick: Boolean, $fossilFreeAlliance: Boolean, $features: [String], $regions: [String], $subregions: [String], $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
-          brands(country: $country, first: $first, topPick: $topPick, fossilFreeAlliance: $fossilFreeAlliance, features: $features, regions: $regions, subregions: $subregions) {
+      query BrandsQuery($country: String, $first: Int, $topPick: Boolean, $sustainableOnly: Boolean, $fossilFreeAlliance: Boolean, $features: [String], $regions: [String], $subregions: [String], $withCommentary: Boolean = false, $withFeatures: Boolean = false) {
+          brands(country: $country, first: $first, topPick: $topPick, recommendedOnly: $sustainableOnly, fossilFreeAlliance: $fossilFreeAlliance, features: $features, regions: $regions, subregions: $subregions) {
               edges {
                   node {
                       name
@@ -131,9 +132,10 @@ export async function getBanksListWithFilter ({
     topPick,
     fossilFreeAlliance,
     features,
-    first: 300,
+    first: 500,
     withCommentary: true,
-    withFeatures: true
+    withFeatures: true,
+    sustainableOnly: sustainableOnly
   }
 
   const json = await callBackend(brandsQuery, variables)


### PR DESCRIPTION
The current query is retrieving all banks on the site and filtering on the sustainable ones client side.  For the eco banks page, we should only get the relevant ones at the query level to improve performance.  This was causing results to be omitted