### PR TITLE
fix: avoid formatter and linter conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ node_modules
 .output
 .env
 dist
-.vscode/
 .wrangler
 .eslintcache
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    // Required in vscode-eslint < v3.0.10 only
+    "eslint.useFlatConfig": true,
+    // Enable eslint as a default formatter
+    "prettier.enable": false,
+    "eslint.format.enable": true,
+    // Auto fix
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit",
+    }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,10 +5,10 @@ export default defineNuxtConfig({
     '@nuxtjs/prismic',
     'nuxt-jsonld',
     '@nuxt/test-utils/module',
-    '@nuxt/eslint'
+    '@nuxt/eslint',
   ],
   prismic: {
-    endpoint: 'bankgreen'
+    endpoint: 'bankgreen',
   },
   runtimeConfig: {
     public: {
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
       ZAPIER_OTHER_SUBMIT: process.env.ZAPIER_OTHER_SUBMIT,
       ZAPIER_CONTACT: process.env.ZAPIER_CONTACT,
       ACTIVE_CAMPAIGN_KEY: process.env.NUXT_PUBLIC_ACTIVE_CAMPAIGN_API_KEY,
-      ACTIVE_CAMPAIGN_URL: process.env.NUXT_PUBLIC_ACTIVE_CAMPAIGN_URL
+      ACTIVE_CAMPAIGN_URL: process.env.NUXT_PUBLIC_ACTIVE_CAMPAIGN_URL,
     },
     STRIPE_SECRET_KEY: process.env.PRIVATE_STRIPE_SECRET_KEY,
     STRIPE_SUBSCRIPTION_PRICE_1:
@@ -36,152 +36,152 @@ export default defineNuxtConfig({
     STRIPE_SUBSCRIPTION_PRICE_5:
       process.env.PRIVATE_STRIPE_SUBSCRIPTION_PRICE_5,
     STRIPE_SUBSCRIPTION_PRICE_6:
-      process.env.PRIVATE_STRIPE_SUBSCRIPTION_PRICE_6
+      process.env.PRIVATE_STRIPE_SUBSCRIPTION_PRICE_6,
   },
   vue: {
     compilerOptions: {
       directiveTransforms: {
         clickaway: () => ({
           props: [],
-          needRuntime: true
-        })
-      }
-    }
+          needRuntime: true,
+        }),
+      },
+    },
   },
   css: ['@/styles/style.css', '@typeform/embed/build/css/widget.css'],
   routeRules: {
     '/sustainable-ethical-banks': { redirect: '/sustainable-eco-banks' },
     '/': { prerender: true },
-    '/faq': { prerender: true }
+    '/faq': { prerender: true },
   },
   app: {
     head: {
       meta: [
         {
-          charset: 'utf-8'
+          charset: 'utf-8',
         },
         {
           'http-equiv': 'x-ua-compatible',
-          content: 'IE-edge'
+          'content': 'IE-edge',
         },
         {
           'http-equiv': 'Content-Language',
-          content: 'en'
+          'content': 'en',
         },
         {
           name: 'apple-mobile-web-app-title',
-          content: 'Find Ethical & Sustainable Banks In Your Area - Bank.Green'
+          content: 'Find Ethical & Sustainable Banks In Your Area - Bank.Green',
         },
         {
           name: 'application-name',
-          content: 'Bank.Green'
+          content: 'Bank.Green',
         },
         {
           name: 'msapplication-TileColor',
-          content: '#12141d'
+          content: '#12141d',
         },
         {
           name: 'theme-color',
-          content: '#12141d'
+          content: '#12141d',
         },
         {
           name: 'viewport',
-          content: 'width=device-width, initial-scale=1.0'
+          content: 'width=device-width, initial-scale=1.0',
         },
         {
           name: 'referrer',
-          content: 'origin'
+          content: 'origin',
         },
         {
           name: 'description',
           content:
-            'Bank.Green is sounding the alarm on the climate-destroying activities of banks while recommending sustainable alternatives and empowering consumer action.'
+            'Bank.Green is sounding the alarm on the climate-destroying activities of banks while recommending sustainable alternatives and empowering consumer action.',
         },
         {
           property: 'og:title',
-          content: 'Find Ethical & Sustainable Banks In Your Area - Bank.Green'
+          content: 'Find Ethical & Sustainable Banks In Your Area - Bank.Green',
         },
         {
           property: 'og:description',
           content:
-            'Bank.Green is sounding the alarm on the climate-destroying activities of banks while recommending sustainable alternatives and empowering consumer action.'
+            'Bank.Green is sounding the alarm on the climate-destroying activities of banks while recommending sustainable alternatives and empowering consumer action.',
         },
         {
           property: 'og:image',
-          content: 'https://bank.green/img/social/social-1664-971.jpg'
+          content: 'https://bank.green/img/social/social-1664-971.jpg',
         },
         {
           property: 'og:image:width',
-          content: '1665'
+          content: '1665',
         },
         {
           property: 'og:image:height',
-          content: '971'
+          content: '971',
         },
         {
           property: 'twitter:image',
-          content: 'https://bank.green/img/social/social-1664-971.jpg'
+          content: 'https://bank.green/img/social/social-1664-971.jpg',
         },
         {
           property: 'og:locale',
-          content: 'en'
+          content: 'en',
         },
         {
           name: 'facebook-domain-verification',
-          content: 'wf6ta1yzc1rnykp1b7jj8vov1c4amh'
-        }
+          content: 'wf6ta1yzc1rnykp1b7jj8vov1c4amh',
+        },
       ],
       link: [
         {
           rel: 'apple-touch-icon',
           sizes: '180x180',
-          href: '/apple-touch-icon.png'
+          href: '/apple-touch-icon.png',
         },
         {
           rel: 'icon',
           type: 'image/png',
           sizes: '32x32',
-          href: '/favicon-32x32.png'
+          href: '/favicon-32x32.png',
         },
         {
           rel: 'icon',
           type: 'image/png',
           sizes: '16x16',
-          href: '/favicon-16x16.png'
+          href: '/favicon-16x16.png',
         },
         {
           rel: 'manifest',
-          href: '/site.webmanifest'
+          href: '/site.webmanifest',
         },
         {
           rel: 'mask-icon',
           href: '/safari-pinned-tab.svg',
-          color: '#12141D'
-        }
+          color: '#12141D',
+        },
       ],
       noscript: [
         {
           children:
-            "We're sorry but Bank.Green doesn't work properly without JavaScript enabled. Please enable it to continue."
-        }
-      ]
-    }
+            "We're sorry but Bank.Green doesn't work properly without JavaScript enabled. Please enable it to continue.",
+        },
+      ],
+    },
   },
   imports: {
-    dirs: ['slices']
+    dirs: ['slices'],
   },
   image: {
     provider: 'prismic',
     none: {},
-    prismic: {}
+    prismic: {},
   },
   nitro: {
-    preset: 'cloudflare'
+    preset: 'cloudflare',
   },
   eslint: {
     checker: true,
     config: {
-      stylistic: true
-    }
+      stylistic: true,
+    },
   },
-});
+})


### PR DESCRIPTION
I added a .vscode workspace settings that:
- Enables eslint as the default formatter and disables prettier to avoid conflicts between linter and formatter
- Fixes lint errors and formats when saving a file

Also, I removed .vscode from .gitignore so this configuration is shared in the repo. 