### PR TITLE
feat: add accreditation about section

### DIFF
--- a/components/accreditation/AccreditationAbout.vue
+++ b/components/accreditation/AccreditationAbout.vue
@@ -1,0 +1,47 @@
+<template>
+  <section class="flex flex-col gap-10 lg:flex-row-reverse min-h-[368px] px-6 lg:px-52 py-16 lg:py-20 bg-primary-dark text-white">
+    <div class="flex flex-col gap-6 max-w-3xl">
+      <h1 class="text-2xl lg:text-4xl font-bold">
+        {{ title }}
+      </h1>
+      <PrismicRichText
+        class="text-white font-medium"
+        :field="description"
+        fallback="This certification is part of the Bank.Green Accrediation Program to certified businesses that have committed to banking with environmentally responsible financial institutions, actively reducing their carbon footprint and building a healthier planet for generations to come."
+      />
+      <p>
+        Are you a business?
+        <NuxtLink
+          class="underline font-medium"
+          to="/contact"
+        >
+          Contact us to get more information ⟶
+        </NuxtLink>
+      </p>
+    </div>
+    <NuxtImg
+      class="w-52 h-52 p-1 bg-white rounded-full"
+      :src="logo"
+      :provider="logoProvider"
+      alt="Accreditation Logo"
+    />
+  </section>
+</template>
+
+<script lang="ts" setup>
+import { asImageSrc } from '@prismicio/helpers'
+import type { AccreditationpageDocumentData } from 'prismicio-types'
+
+interface Props {
+  title?: AccreditationpageDocumentData['about_title']
+  description?: AccreditationpageDocumentData['about_description']
+  logo?: AccreditationpageDocumentData['aboutlogo']
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  title: 'About the Bank.Green Certification',
+})
+
+const logo = asImageSrc(props.logo) ?? '/img/certification/fossil-free-certified.png'
+const logoProvider = props.logo ? '' : 'none'
+</script>

--- a/components/accreditation/AccreditationAbout.vue
+++ b/components/accreditation/AccreditationAbout.vue
@@ -9,10 +9,10 @@
         :field="description"
         fallback="This certification is part of the Bank.Green Accrediation Program to certified businesses that have committed to banking with environmentally responsible financial institutions, actively reducing their carbon footprint and building a healthier planet for generations to come."
       />
-      <p>
+      <p class="">
         Are you a business?
         <NuxtLink
-          class="underline font-medium"
+          class="underline font-medium inline-block"
           to="/contact"
         >
           Contact us to get more information ⟶

--- a/components/accreditation/AccreditationAbout.vue
+++ b/components/accreditation/AccreditationAbout.vue
@@ -9,7 +9,7 @@
         :field="description"
         fallback="This certification is part of the Bank.Green Accrediation Program to certified businesses that have committed to banking with environmentally responsible financial institutions, actively reducing their carbon footprint and building a healthier planet for generations to come."
       />
-      <p class="">
+      <p>
         Are you a business?
         <NuxtLink
           class="underline font-medium inline-block"

--- a/components/accreditation/AccreditationHero.vue
+++ b/components/accreditation/AccreditationHero.vue
@@ -1,56 +1,65 @@
 <template>
-  <div
-    class="relative flex flex-col items-center gap-10 border rounded-2xl w-full max-w-7xl min-h-[504px] px-4 py-10 bg-white text-center"
-  >
-    <h1 class="text-3xl lg:text-5xl font-semibold text-gray-800">
-      <template v-if="title">
-        {{ title }}
-      </template>
-      <template v-else>
-        Your money is building a <span class="green-line">greener future</span>
-      </template>
-    </h1>
-    <div class="lg:px-16 text-base lg:text-xl text-gray-700 max-w-4xl">
-      <template v-if="description">
-        {{ description }}
-      </template>
-      <template v-else>
-        <p class="pb-6">
-          By choosing to spend your money with this business, you are ensuring your financial support
-          contributes
-          to a sustainable, liveable future.
-        </p>
-        <p>
-          Wich means your money is supporting projects like:
-        </p>
-      </template>
+  <section class="bg-gradient-to-b from-sushi-50 to-sushi-100 pt-28 max-w-screen">
+    <div class="page-fade-in relative contain pb-20 lg:pt-12 z-10">
+      <div
+        class="relative flex flex-col items-center gap-10 border rounded-2xl w-full max-w-7xl min-h-[504px] px-4 py-10 bg-white text-center"
+      >
+        <h1 class="text-3xl lg:text-5xl font-semibold text-gray-800">
+          <template v-if="title">
+            {{ title }}
+          </template>
+          <template v-else>
+            Your money is building a <span class="green-line">greener future</span>
+          </template>
+        </h1>
+        <div class="lg:px-16 text-base lg:text-xl text-gray-700 max-w-4xl">
+          <PrismicRichText
+            v-if="description"
+            class="text-white font-medium"
+            :field="description"
+          />
+          <template v-else>
+            <p class="pb-6">
+              By choosing to spend your money with this business, you are ensuring your financial support
+              contributes
+              to a sustainable, liveable future.
+            </p>
+            <p>
+              Wich means your money is supporting projects like:
+            </p>
+          </template>
+        </div>
+        <AccreditationProjectCarousel
+          class="lg:absolute lg:bottom-0 lg:left-80 lg:translate-y-16"
+          :projects="projects"
+        />
+        <NuxtImg
+          class="absolute bottom-0 lg:left-36 w-32 h-32 translate-y-16 lg:translate-y-10"
+          :src="heroLogo"
+          :provider="heroLogoProvider"
+          alt="Accreditation Logo"
+        />
+      </div>
     </div>
-    <AccreditationProjectCarousel
-      class="lg:absolute lg:bottom-0 lg:left-80 lg:translate-y-16"
-      :projects="projects"
-    />
-    <NuxtImg
-      class="absolute bottom-0 lg:left-36 w-32 h-32 translate-y-16 lg:translate-y-10"
-      :src="heroLogo"
-      :provider="heroLogoProvider"
-      alt="Accreditation Logo"
-    />
-  </div>
+    <Swoosh />
+  </section>
 </template>
+
 <script lang="ts" setup>
 import { asImageSrc } from '@prismicio/helpers'
 import type { AccreditationpageDocumentData, AccreditationpageDocumentDataProjectsItem } from 'prismicio-types'
 
 const props = defineProps<{
-    title?: AccreditationpageDocumentData['hero_title'],
-    description?: AccreditationpageDocumentData['hero_description'],
-    logo?: AccreditationpageDocumentData['hero_logo'],
-    projects?: AccreditationpageDocumentDataProjectsItem[],
+  title?: AccreditationpageDocumentData['hero_title']
+  description?: AccreditationpageDocumentData['hero_description']
+  logo?: AccreditationpageDocumentData['hero_logo']
+  projects?: AccreditationpageDocumentDataProjectsItem[]
 }>()
 
 const heroLogo = asImageSrc(props.logo) ?? '/img/certification/fossil-free-certified.png'
 const heroLogoProvider = props.logo ? '' : 'none'
 </script>
+
 <style>
 .green-line {
   padding-bottom: 20px;

--- a/pages/accreditation/[slug].vue
+++ b/pages/accreditation/[slug].vue
@@ -1,30 +1,33 @@
 <template>
   <div class="page">
-    <section class="bg-gradient-to-b from-sushi-50 to-sushi-100 pt-28 max-w-screen">
-      <div class="page-fade-in relative contain pb-20 lg:pt-12 z-10">
-        <AccreditationHero
-          :title="accred?.data.hero_title"
-          :logo="accred?.data.hero_logo"
-          :description="accred?.data.hero_description"
-          :projects="accred?.data.projects"
-        />
-      </div>
-      <Swoosh />
+    <AccreditationHero
+      :title="accred?.data.hero_title"
+      :logo="accred?.data.hero_logo"
+      :description="accred?.data.hero_description"
+      :projects="accred?.data.projects"
+    />
+
+    <section>
+      <!-- Sharing section -->
     </section>
+
+    <AccreditationAbout
+      :title="accred?.data.about_title"
+      :description="accred?.data.about_description"
+      :logo="accred?.data.aboutlogo"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-
 const route = useRoute()
 
 const { client } = usePrismic()
 const slug = route.params.slug ?? ''
 const { data: accred } = await useAsyncData(slug[0], () =>
-  client.getByUID('accreditationpage', slug[0])
+  client.getByUID('accreditationpage', slug[0]),
 )
 
 /*
 usePrismicSEO(gpe.value?.data) */
-
 </script>


### PR DESCRIPTION
I created the `AccreditationAbout.vue` component and refactored the `AccreditationHero.vue` section so the page `accreditation/[slug].vue` is cleaner. 

After merging the [ carousel PR](https://github.com/bank-green/nuxt-bank-green/pull/179), I'll fix the confict with `AccreditationHero.vue` in this PR.