### PR TITLE
This apparently fixes the emojis

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -124,7 +124,7 @@
     </div>
     <!-- <pre>
             {{ JSON.stringify(home, null, 2) }}
-        </pre> -->
+         </pre> -->
     <div
       class="flex flex-col md:flex-row items-center justify-center py-16 contain"
     >

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -45,14 +45,14 @@
                 </div>
               </template>
             </ClientOnly>
-            <NuxtLink
-              :to="`/banks/${bank?.['tag']}`"
+            <a
+              :href="`/banks/${bank?.['tag']}`"
               class="flex-initial md:w-48 button-green text-primary-dark"
               :class="{ disabled: !bank }"
               @click="onCheckBankClick"
             >
               Check My Bank
-            </NuxtLink>
+            </a>
           </div>
 
           <div


### PR DESCRIPTION
I noticed they only dont work when navigating to them from a Nuxtlink, a href doesnt have the issues

TIL from chatGPT which seems like a likely cause of a page load issue that doesnt happen on refresh:

> The primary difference between NuxtLink and an a tag (href) lies in how they handle navigation in a Nuxt.js application:
> 
> Client-Side Navigation: NuxtLink is a special component provided by Nuxt.js (and Vue Router). It enables navigation between pages without a full-page reload, leveraging Vue's single-page application (SPA) behavior.

Any additional load time should be pretty small with the page caching