### PR TITLE
GROOT-392 Move routing functionality of BankSearch to homepage

### DIFF
--- a/components/forms/banks/BankSearch.vue
+++ b/components/forms/banks/BankSearch.vue
@@ -116,7 +116,6 @@ const props = withDefaults(defineProps<{
 })
 
 const emit = defineEmits(['update:modelValue', 'searchInputChange'])
-const router = useRouter()
 
 const pageStart = new Date()
 const banks = ref([])
@@ -177,7 +176,6 @@ async function onSelectBank(item: { name: string, tag: string }) {
   selectedItem.value = item.name
   emit('update:modelValue', item)
   isShowing.value = false
-  router.push(`banks/${item.tag}`)
 }
 
 function onCloseClick() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -220,6 +220,8 @@ import { components } from '~~/slices'
 import { usePrismicSEO } from '~~/composables/useHeadHelpers'
 import isEmptyPrismicField from '~/utils/prismic/isEmptyPrismicField'
 
+const router = useRouter()
+
 const sliceComps = ref(defineSliceZoneComponents(components))
 
 const { bank, warningsMap } = useContactForm('homepage', ['bank'])
@@ -245,5 +247,9 @@ const { country } = useCountry()
 
 watch(country, (_) => {
   bank.value = null
+})
+
+watch(bank, ({ tag }) => {
+  if (tag) router.push(`banks/${tag}`)
 })
 </script>


### PR DESCRIPTION
**About**:
This PR fixes the issue of all instances of the `BankSearch` text box input automatically redirecting  to the bank page. We want that functionality on homepage's `BankSearch`, but not in the `BankSearch` component in other locations (sign up for example).

**Issue**:
the automatic redirection is baked-in directly onto the `BankSearch` input, causing all implementations of it to redirect.

**Solution**:
because the redirection functionality is only desired at the homepage's implementation, it makes sense to "lift the functionality" to that location.