### PR TITLE
Matthew/groot 407 disable glossary and re enable builds every 24 hr

### DIFF
--- a/.github/workflows/build_and_deploy_main.yaml
+++ b/.github/workflows/build_and_deploy_main.yaml
@@ -3,11 +3,11 @@ name: Build and Deploy Main
 on:
   push:
     branches: [main]
-  # Disabling since this may be causing usage spikes
-  # Trigger every hour
-  # schedule:
-  #  - cron: "0 * * * *"
-  # workflow_dispatch:
+  Disabling since this may be causing usage spikes
+  Trigger every hour
+  schedule:
+   - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:

--- a/components/bank/BankDescription.vue
+++ b/components/bank/BankDescription.vue
@@ -1,28 +1,8 @@
 <script setup lang="ts">
-import { onMounted, watch, ref } from 'vue'
-import { addGlossaryToText } from '~/utils/addGlossaryToText'
+import { ref } from 'vue'
 
 const props = defineProps<{ text: string }>()
 const processedText = ref(props.text) // Default to initial text
-
-const { client } = usePrismic()
-const { data: glossarypage } = await useAsyncData('glossary', () => client.getSingle('glossarypage'))
-usePrismicSEO(glossarypage?.value?.data)
-
-onMounted(async () => {
-  const glossaryData = glossarypage?.value?.data
-  if (glossaryData?.terms) {
-    const terms = glossaryData.terms.map(term => ({
-      name: term.term,
-      tooltip: term.tooltip,
-    }))
-    processedText.value = addGlossaryToText(props.text, terms)
-  }
-})
-
-watch(() => props.text, (newText) => {
-  processedText.value = addGlossaryToText(newText, glossaryData?.terms)
-})
 </script>
 
 <template>


### PR DESCRIPTION
this ticket removes glossary logic for the bank details page, also re-enables to cron job build but for every day instead of every hour.

this was done as a short term solution for our issues with nuxt's pre-rendering, which currently calls the prismic glossary fetch for every brand during every build (resulting in millions of calls to prismic)
