### PR TITLE
Matthew/groot 441 move state next to country in sidebar

### DIFF
--- a/components/forms/BankLocationSearch.vue
+++ b/components/forms/BankLocationSearch.vue
@@ -21,8 +21,10 @@ const props = withDefaults(
     dark?: boolean;
     isEmbrace?: boolean;
     hideLocation?: boolean;
+    isLandingPage?: boolean;
   }>(),
   {
+    isLandingPageSearch: false,
     warning: false,
     dark: false,
     bankTitle: '',
@@ -143,29 +145,35 @@ async function loadBanks() {
 </script>
 
 <template>
-  <LocationSearch
-    v-if="!isEmbrace && !hideLocation"
-    ref="locationSearch"
-    v-model="country"
-    :dark="dark"
-    class="col-span-2"
-    :title="locationTitle"
-    :class="locationSearchClasses"
-  />
-  <BaseField
-    v-if="isValidStateCountry(country) && !hideLocation"
-    class="relative col-span-2"
-    name="stateSearch"
-    :dark="dark"
-    title="State"
-    :class="locationSearchClasses"
+  <div
+    :class="
+      isLandingPage ? 'flex flex-row mb-2 gap-x-2' : 'flex flex-col gap-y-2'
+    "
   >
-    <StateSearch
-      ref="statePicker"
-      :options="Object.keys(STATES_BY_COUNTRY?.[country])"
-      @select="onStateSelect"
+    <LocationSearch
+      v-if="!isEmbrace && !hideLocation"
+      ref="locationSearch"
+      v-model="country"
+      :dark="dark"
+      class="col-span-2"
+      :title="locationTitle"
+      :class="locationSearchClasses"
     />
-  </BaseField>
+    <BaseField
+      v-if="isValidStateCountry(country) && !hideLocation"
+      class="relative col-span-2"
+      name="stateSearch"
+      :dark="dark"
+      title="State"
+      :class="locationSearchClasses"
+    >
+      <StateSearch
+        ref="statePicker"
+        :options="Object.keys(STATES_BY_COUNTRY?.[country])"
+        @select="onStateSelect"
+      />
+    </BaseField>
+  </div>
   <BankSearch
     ref="bankSearch"
     v-model="bank"

--- a/components/forms/BankLocationSearch.vue
+++ b/components/forms/BankLocationSearch.vue
@@ -146,9 +146,10 @@ async function loadBanks() {
 
 <template>
   <div
-    :class="
-      isLandingPage ? 'flex flex-row mb-2 gap-x-2' : 'flex flex-col gap-y-2'
-    "
+    :class="[
+      'flex flex-col gap-y-2 w-full justify-center',
+      isLandingPage && 'items-center lg:flex-row lg:mb-2 lg:gap-x-2',
+    ]"
   >
     <LocationSearch
       v-if="!isEmbrace && !hideLocation"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -23,6 +23,7 @@
                 :warning="warningsMap['bank']"
                 bank-search-classes="location-search-input"
                 location-search-classes="location-search-input"
+                is-landing-page
               />
               <template #fallback>
                 <div class="relative location-search-input text-gray-800">

--- a/queries/brands.gql
+++ b/queries/brands.gql
@@ -1,5 +1,5 @@
 query BrandsByCountryQuery($country: String, $state: String) {
-  brands(country: $country, displayOnWebsite: true, stateLicensed: $state) {
+  brands(country: $country, stateLicensed: $state) {
     edges {
       node {
         name


### PR DESCRIPTION
Here's the PR for re-enabling credit unions and also restyling the landing page bank search's state input to be in a 'row'.
for re-enabling the credit unions the solution is the remove the `displayOnWebsite: true` flag.

for restyling the solution is to put a flex wrapper to make the inputs a row at desired break point. 
A `isLandingPageSearch` flag is added because the component is used in several locations but this styling is unique to the landing page.  I'm not totally happy with the solution but I chose the CSS solution because I found it to be the least intrusive. 
all the solution i tried with re-rendering the components differently with vue/js got hairy with event/state management and required much more refactoring

https://github.com/user-attachments/assets/f865c7ea-f0d9-452c-8550-6cad4119b4d7

