### PR TITLE
Drop-in clearbit replacement with brandfetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Bank.Green is a Nuxt 3 application that helps users find ethical and sustainable banks. The site uses Prismic as a headless CMS, GraphQL for data fetching, and is deployed on Cloudflare Workers.
+
+## Development Commands
+
+- **Development server**: `npm run dev`
+- **Build**: `npm run build`
+- **Preview**: `npm run preview` (uses Wrangler to preview the Cloudflare Worker locally)
+- **Tests**: `npm run test` (runs Vitest tests with `*.spec.ts` files)
+- **Linting**: `npm run lint` (check all files) or `npm run lint-staged` (staged files only)
+- **Lint fix**: `npm run lint:fix` (all files) or `npm run lint-staged:fix` (staged files)
+- **Formatting**: `npm run format` (Prettier format) or `npm run format:check` (check formatting)
+
+## Architecture
+
+### Core Structure
+- **Pages**: Standard Nuxt 3 file-based routing in `/pages`
+- **Components**: Organized by feature areas (bank/, eco-bank/, forms/, nav/, etc.)
+- **Slices**: Prismic slice components in `/slices` for CMS content blocks
+- **Composables**: Vue composables in `/composables` for reusable logic
+- **Utils**: Utility functions in `/utils` organized by domain
+- **Styles**: Tailwind CSS with custom color palette and design tokens
+
+### Key Features
+- **Bank Search**: Location-based sustainable bank discovery
+- **CMS Integration**: Prismic for content management via Slice Machine
+- **GraphQL Data**: Uses `nuxt-graphql-client` with `.gql` query files
+- **Form Handling**: Contact forms, bank submissions, and surveys
+- **Social Features**: Sharing, embracing campaigns, donation flows
+
+### Prismic CMS
+- **Critical**: Always use Slice Machine (`npm run slicemachine`) for creating/editing custom types
+- **Never** use the Prismic dashboard web interface for custom types - this can delete content
+- Custom types are defined in `/customtypes`
+- Slices are in `/slices` with auto-imports configured
+
+### Data Layer
+- **GraphQL**: Queries in `/queries/*.gql` files for type generation
+- **Server API**: Routes in `/server/api/` for backend functionality
+- **Runtime Config**: Environment variables configured in `nuxt.config.ts`
+
+### Component Organization
+- **Feature-based**: Components grouped by domain (bank/, eco-bank/, forms/)
+- **Shared components**: Common UI elements in root `/components`
+- **Client components**: Use `.client.vue` suffix for client-only components
+
+### Styling
+- **Tailwind CSS**: Custom design system with brand colors (sushi green, sunglow yellow)
+- **Typography**: Custom prose styles for CMS content
+- **Responsive**: Mobile-first with custom breakpoints
+
+## Testing
+
+- **Framework**: Vitest with `@nuxt/test-utils`
+- **Test files**: `*.spec.ts` files in `/__tests__` directory
+- **Environment**: Uses Nuxt test environment with mocked intersectionObserver
+- **Run tests**: `npm run test`
+
+## Deployment
+
+- **Platform**: Cloudflare Workers with Wrangler CLI
+- **Staging**: `npm run stage` (deploys to test.bank.green)
+- **Production**: `npm run deploy` (deploys to bank.green)
+- **Requirements**: Wrangler CLI installed globally and authenticated
+
+## Code Standards
+
+- **ESLint**: Nuxt ESLint config with Prettier integration
+- **TypeScript**: Full TypeScript support with strict configuration
+- **Vue 3**: Composition API with `<script setup>` syntax
+- **Auto-imports**: Nuxt auto-imports for composables, utils, and components
+- **Git hooks**: Husky with lint-staged for pre-commit linting
+
+## Environment Setup
+
+- **Node.js**: >= 22.19.0 (see `.nvmrc`)
+- **Package manager**: npm
+- **IDE**: VS Code with Vue, ESLint, and Prettier extensions recommended

--- a/components/icons/ClearbitLogo.vue
+++ b/components/icons/ClearbitLogo.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-const showClearbit = ref(true)
-const { public: { BRANDFETCH_CLIENT_ID: brandFetchClientId } } = useRuntimeConfig()
+const showBrandIcon = ref(true)
+/** BrandFetch requires the client ID to be directly embedded in each request, so there's no point in obfuscating it */
+const brandFetchClientId = "1idgd9eLaoZ3OpDvC0X"
 
 function handleError() {
-  showClearbit.value = false
+  showBrandIcon.value = false
 }
 
 const props = withDefaults(
@@ -52,7 +53,7 @@ const src = computed(() => {
         return '/img/logos/green_got.png'
     }
 
-    return `https://cdn.brandfetch.io/${urlDomain.value}/icon/fallback/lettermark/h/${props.size * 2}/w/${props.size * 2}?c=${brandFetchClientId}`
+    return `https://cdn.brandfetch.io/${urlDomain.value}/icon/fallback/lettermark/h/${props.size*2}/w/${props.size*2}?c=${brandFetchClientId}`
   }
   return ''
 })
@@ -61,7 +62,7 @@ const src = computed(() => {
 <template>
   <ClientOnly>
     <img
-      v-if="showClearbit"
+      v-if="showBrandIcon"
       :src="src"
       :class="`object-contain`"
       :style="`width: ${size}px; height: ${size}px`"

--- a/components/icons/ClearbitLogo.vue
+++ b/components/icons/ClearbitLogo.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const showClearbit = ref(true)
+const { public: { BRANDFETCH_CLIENT_ID: brandFetchClientId } } = useRuntimeConfig()
 
 function handleError() {
   showClearbit.value = false
@@ -51,7 +52,7 @@ const src = computed(() => {
         return '/img/logos/green_got.png'
     }
 
-    return `https://logo.clearbit.com/${urlDomain.value}?size=${props.size * 2}`
+    return `https://cdn.brandfetch.io/${urlDomain.value}/icon/fallback/lettermark/h/${props.size * 2}/w/${props.size * 2}?c=${brandFetchClientId}`
   }
   return ''
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,7 +40,6 @@ export default defineNuxtConfig({
       ACTIVE_CAMPAIGN_URL: process.env.NUXT_PUBLIC_ACTIVE_CAMPAIGN_URL,
       GQL_HOST:
         process.env.PUBLIC_DATA_URL || 'https://data.bank.green/graphql',
-      BRANDFETCH_CLIENT_ID: process.env.BRANDFETCH_CLIENT_ID,
     },
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -40,6 +40,7 @@ export default defineNuxtConfig({
       ACTIVE_CAMPAIGN_URL: process.env.NUXT_PUBLIC_ACTIVE_CAMPAIGN_URL,
       GQL_HOST:
         process.env.PUBLIC_DATA_URL || 'https://data.bank.green/graphql',
+      BRANDFETCH_CLIENT_ID: process.env.BRANDFETCH_CLIENT_ID,
     },
   },
 


### PR DESCRIPTION
Simple drop-in replacement of clearbit with brandfetch, which allows 1,000,000 requests / month for free with no attribution. To stay within their license requirements, we have to have the client key directly embedded in the requests, which means exposing them to the browser. That being the case, there's no sense in trying to hide that key via a .env / Nuxt config.